### PR TITLE
Correção de erro tramite documento restrito ou sigiloso cancelado

### DIFF
--- a/docs/changelogs/CHANGELOG-2.1.6.md
+++ b/docs/changelogs/CHANGELOG-2.1.6.md
@@ -1,0 +1,39 @@
+# NOTAS DE VERSÃO MOD-SEI-PEN (versão 2.1.6)
+
+Este documento descreve as principais mudanças aplicadas nesta versão do módulo de integração do SEI com o Barramento de Serviços do PEN. 
+
+As melhorias entregues em cada uma das versões são cumulativas, ou seja, contêm todas as implementações realizada em versões anteriores.
+
+Para maiores informações sobre os procedimentos de instalação ou atualização, acesse os seguintes documentos localizados no pacote de distribuição mod-sei-pen-VERSAO.zip:
+
+* **INSTALACAO.md** - Procedimento de instalação e configuração do módulo
+* **ATUALIZACAO.md** - Procedimento específicos para atualização de uma versão anterior
+
+
+## Lista de Melhorias e Correções de Problemas
+
+#### Issue #60 - Correção de erro ao substituir hierarquia de órgão sem pai (@UNIDADE_DESTINO_HIRARQUIA@)
+
+O módulo estáva retornado no histórico '@UNIDADE_DESTINO_HIRARQUIA@' nos casos que não encontrava uma hierarquia superior. Agora retornará vazio.
+
+
+
+#### Issue #63 - Ajuste em lógica para truncar textos longos
+
+A lógica atual apresentava erros se a última palavra era menor que a reticência.
+
+
+#### Issue #43 - Adicionado mensagens de ajuda na página de configuração do Barramento
+
+Adicionado mensagens de orientação para o correto preenchimento por parte do usuário
+
+
+#### Issue #44 - Obrigatoriedade na seleção de um Tipo de Processo publico e restrito para configuração do módulo
+
+O sistema estava permitindo a configuração de processos sigilosos ou desativados, o que provocava erro posteriormente durante o recebimento
+
+
+#### Issue #45 - Impedir a configuração de Tipos de Processos sem a devida indicação Classificação de Assunto
+
+O sistema estava permitindo a configuração de processos sem configuração de assuntos, o que provocava erro posteriormente durante o recebimento
+

--- a/docs/changelogs/CHANGELOG-2.1.6.md
+++ b/docs/changelogs/CHANGELOG-2.1.6.md
@@ -17,7 +17,6 @@ Para maiores informações sobre os procedimentos de instalação ou atualizaç�
 O módulo estáva retornado no histórico '@UNIDADE_DESTINO_HIRARQUIA@' nos casos que não encontrava uma hierarquia superior. Agora retornará vazio.
 
 
-
 #### Issue #63 - Ajuste em lógica para truncar textos longos
 
 A lógica atual apresentava erros se a última palavra era menor que a reticência.
@@ -37,3 +36,6 @@ O sistema estava permitindo a configuração de processos sigilosos ou desativad
 
 O sistema estava permitindo a configuração de processos sem configuração de assuntos, o que provocava erro posteriormente durante o recebimento
 
+#### Issue #70 - Homologação do mod-sei-pen para funcionamento com SEI 3.1.7
+
+Homologação e liberação do funcionamento do módulo para a versão 3.1.7 do SEI

--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -2,7 +2,7 @@
 
 class PENIntegracao extends SeiIntegracao
 {
-    const VERSAO_MODULO = "2.1.5";
+    const VERSAO_MODULO = "2.1.6";
     const PARAMETRO_VERSAO_MODULO_ANTIGO = 'PEN_VERSAO_MODULO_SEI';
     const PARAMETRO_VERSAO_MODULO = 'VERSAO_MODULO_PEN';
 

--- a/src/pen_map_hipotese_legal_envio_cadastrar.php
+++ b/src/pen_map_hipotese_legal_envio_cadastrar.php
@@ -69,11 +69,22 @@ try {
         if(array_key_exists(PEN_PAGINA_GET_ID, $_GET) && !empty($_GET[PEN_PAGINA_GET_ID])) {
             $objPenRelHipoteseLegalDTO->setDblIdMap($_GET[PEN_PAGINA_GET_ID]);
             $mapeamento = $objPenRelHipoteseLegalRN->alterar($objPenRelHipoteseLegalDTO);
-            $numIdMapeamento = $_GET[PEN_PAGINA_GET_ID];
+
+            if(!method_exists($mapeamento, 'contemValidacoes')){
+                $numIdMapeamento = $_GET[PEN_PAGINA_GET_ID];
+            }
         }
         else {
             $mapeamento = $objPenRelHipoteseLegalRN->cadastrar($objPenRelHipoteseLegalDTO);
-            $numIdMapeamento = $mapeamento->getDblIdMap();
+            
+            if(!method_exists($mapeamento, 'contemValidacoes')){
+                $numIdMapeamento = $mapeamento->getDblIdMap();
+            }
+        }
+
+        if(method_exists($mapeamento, 'contemValidacoes')){
+            $arrObjInfraValidacao = $mapeamento->getArrObjInfraValidacao(0);
+            $objPagina->adicionarMensagem(sprintf('%s '. $arrObjInfraValidacao[0]->getStrDescricao(), PEN_PAGINA_TITULO), InfraPagina::$TIPO_MSG_AVISO);
         }
 
         header('Location: '.$objSessao->assinarLink('controlador.php?acao='.PEN_RECURSO_BASE.'_listar&acao_origem='.$_GET['acao'].'&id_mapeamento='.$numIdMapeamento.PaginaSEI::getInstance()->montarAncora($numIdMapeamento)));

--- a/src/pen_map_hipotese_legal_recebimento_cadastrar.php
+++ b/src/pen_map_hipotese_legal_recebimento_cadastrar.php
@@ -68,13 +68,23 @@ try {
         if(array_key_exists(PEN_PAGINA_GET_ID, $_GET) && !empty($_GET[PEN_PAGINA_GET_ID])) {
             $objPenRelHipoteseLegalDTO->setDblIdMap($_GET[PEN_PAGINA_GET_ID]);
             $objPenRelHipoteseLegalRN->alterar($objPenRelHipoteseLegalDTO);
-            $numIdMapeamento = $_GET[PEN_PAGINA_GET_ID];
+            
+            if(!method_exists($mapeamento, 'contemValidacoes')){
+                $numIdMapeamento = $_GET[PEN_PAGINA_GET_ID];
+            }            
         }
         else {
             $mapeamento = $objPenRelHipoteseLegalRN->cadastrar($objPenRelHipoteseLegalDTO);
-            $numIdMapeamento = $mapeamento->getDblIdMap();
+            
+            if(!method_exists($mapeamento, 'contemValidacoes')){
+                $numIdMapeamento = $mapeamento->getDblIdMap();
+            }
         }
 
+        if(method_exists($mapeamento, 'contemValidacoes')){
+            $arrObjInfraValidacao = $mapeamento->getArrObjInfraValidacao(0);
+            $objPagina->adicionarMensagem(sprintf('%s '. $arrObjInfraValidacao[0]->getStrDescricao(), PEN_PAGINA_TITULO), InfraPagina::$TIPO_MSG_AVISO);
+        }
 
         header('Location: '.$objSessao->assinarLink('controlador.php?acao='.PEN_RECURSO_BASE.'_listar&acao_origem='.$_GET['acao'].'&acao_origem='.$_GET['acao'].'&id_mapeamento='.$numIdMapeamento.PaginaSEI::getInstance()->montarAncora($numIdMapeamento)));
         exit(0);

--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -1979,13 +1979,22 @@ class ExpedirProcedimentoRN extends InfraRN {
                         $objInfraException->adicionarValidacao($strDescricao, $strAtributoValidacao);
                     }
 
-                    if (!empty($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()) && empty($objPenRelHipoteseLegalEnvioRN->getIdHipoteseLegalPEN($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()))) {
-                        $objHipoteseLegalDTO = new HipoteseLegalDTO();
-                        $objHipoteseLegalDTO->setNumIdHipoteseLegal($objDocumentoDTO->getNumIdHipoteseLegalProtocolo());
-                        $objHipoteseLegalDTO->retStrNome();
-                        $objHipoteseLegalRN = new HipoteseLegalRN();
-                        $dados = $objHipoteseLegalRN->consultar($objHipoteseLegalDTO);
-                        $objInfraException->adicionarValidacao('Hipótese legal "'.$dados->getStrNome().'" do documento '.$objDocumentoDTO->getStrNomeSerie(). ' ' . $objDocumentoDTO->getStrProtocoloDocumentoFormatado() .' não mapeada', $strAtributoValidacao);
+                    $objHipoteseLegalDTO = new HipoteseLegalDTO();
+                    $objHipoteseLegalDTO->setNumIdHipoteseLegal($objDocumentoDTO->getNumIdHipoteseLegalProtocolo());
+                    $objHipoteseLegalDTO->setBolExclusaoLogica(false);
+                    $objHipoteseLegalDTO->retStrNome();
+                    $objHipoteseLegalDTO->retStrSinAtivo();
+                    $objHipoteseLegalRN = new HipoteseLegalRN();
+                    $dados = $objHipoteseLegalRN->consultar($objHipoteseLegalDTO);
+
+                    if ($objDocumentoDTO->getStrStaNivelAcessoLocalProtocolo()!=ProtocoloRN::$NA_PUBLICO){
+                        if (!empty($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()) && empty($objPenRelHipoteseLegalEnvioRN->getIdHipoteseLegalPEN($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()))) {
+                            $objInfraException->adicionarValidacao('Hipótese legal "'.$dados->getStrNome().'" do documento '.$objDocumentoDTO->getStrNomeSerie(). ' ' . $objDocumentoDTO->getStrProtocoloDocumentoFormatado() .' não mapeada', $strAtributoValidacao);
+                        }else{
+                            if($dados->getStrSinAtivo() == 'N'){
+                                $objInfraException->adicionarValidacao('Hipótese legal "'.$dados->getStrNome().'" do documento '.$objDocumentoDTO->getStrNomeSerie(). ' ' . $objDocumentoDTO->getStrProtocoloDocumentoFormatado() .' está inativa', $strAtributoValidacao);
+                            }
+                        }
                     }
                 }
             }
@@ -2004,7 +2013,7 @@ class ExpedirProcedimentoRN extends InfraRN {
         $arrObjAtividadeDTO = $this->objAtividadeRN->listarRN0036($objAtividadeDTO);
 
         if(isset($arrObjAtividadeDTO) && count($arrObjAtividadeDTO) > 1) {
-            $strSiglaUnidade = implode(', ', InfraArray::converterArrInfraDTO($arrObjAtividadeDTO, 'SiglaUnidade'));
+            $strSiglaUnidade = implode(', ', InfraArray::converterArrInfraDTO1($arrObjAtividadeDTO, 'SiglaUnidade'));
             $objInfraException->adicionarValidacao("Não é possível tramitar um processo aberto em mais de uma unidade. ($strSiglaUnidade)", $strAtributoValidacao);
         }
     }
@@ -2029,17 +2038,22 @@ class ExpedirProcedimentoRN extends InfraRN {
                 $objInfraException->adicionarValidacao('Não é possível tramitar um processo de nível restrito sem a hipótese legal mapeada.', $strAtributoValidacao);
             }
 
+            $objHipoteseLegalDTO = new HipoteseLegalDTO();
+            $objHipoteseLegalDTO->setNumIdHipoteseLegal($objProcedimentoDTO->getNumIdHipoteseLegalProtocolo());
+            $objHipoteseLegalDTO->setBolExclusaoLogica(false);
+            $objHipoteseLegalDTO->retStrNome();
+            $objHipoteseLegalDTO->retStrSinAtivo();
+            $objHipoteseLegalRN = new HipoteseLegalRN();
+            $dados = $objHipoteseLegalRN->consultar($objHipoteseLegalDTO);
+
             $objPenRelHipoteseLegalEnvioRN = new PenRelHipoteseLegalEnvioRN();
-            if (!empty($objProcedimentoDTO->getNumIdHipoteseLegalProtocolo()) && empty($objPenRelHipoteseLegalEnvioRN->getIdHipoteseLegalPEN($objProcedimentoDTO->getNumIdHipoteseLegalProtocolo()))) {
-                $objHipoteseLegalDTO = new HipoteseLegalDTO();
-                $objHipoteseLegalDTO->setNumIdHipoteseLegal($objProcedimentoDTO->getNumIdHipoteseLegalProtocolo());
-                $objHipoteseLegalDTO->retStrNome();
-                $objHipoteseLegalRN = new HipoteseLegalRN();
-                $dados = $objHipoteseLegalRN->consultar($objHipoteseLegalDTO);
-                if (!empty($dados)) {
+            if(!empty($dados)){
+                if (!empty($objProcedimentoDTO->getNumIdHipoteseLegalProtocolo()) && empty($objPenRelHipoteseLegalEnvioRN->getIdHipoteseLegalPEN($objProcedimentoDTO->getNumIdHipoteseLegalProtocolo()))) {
                     $objInfraException->adicionarValidacao('Hipótese legal "' . $dados->getStrNome() . '" do processo ' . $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado() . ' não mapeada', $strAtributoValidacao);
                 }else{
-                    $objInfraException->adicionarValidacao('Verificar se a Hipótese legal do processo ' . $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado() . ' está ativa.', $strAtributoValidacao);
+                    if($dados->getStrSinAtivo() == 'N'){
+                        $objInfraException->adicionarValidacao('Hipótese legal "' . $dados->getStrNome() . '" do processo ' . $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado() . ' está inativa', $strAtributoValidacao);
+                    }
                 }
             }
         }

--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -1968,23 +1968,25 @@ class ExpedirProcedimentoRN extends InfraRN {
                 $objDocMapDTO->unSetTodos();
                 $objDocMapDTO->setNumIdSerie($objDocumentoDTO->getNumIdSerie());
 
-                if(empty($strMapeamentoEnvioPadrao) && $objGenericoBD->contar($objDocMapDTO) == 0) {
-                    $strDescricao = sprintf(
-                        'Não existe mapeamento de envio para %s no documento %s',
-                        $objDocumentoDTO->getStrNomeSerie(),
-                        $objDocumentoDTO->getStrProtocoloDocumentoFormatado()
-                    );
+                if($objDocumentoDTO->getStrStaEstadoProtocolo() != ProtocoloRN::$TE_DOCUMENTO_CANCELADO){
+                    if(empty($strMapeamentoEnvioPadrao) && $objGenericoBD->contar($objDocMapDTO) == 0) {
+                        $strDescricao = sprintf(
+                            'Não existe mapeamento de envio para %s no documento %s',
+                            $objDocumentoDTO->getStrNomeSerie(),
+                            $objDocumentoDTO->getStrProtocoloDocumentoFormatado()
+                        );
 
-                    $objInfraException->adicionarValidacao($strDescricao, $strAtributoValidacao);
-                }
+                        $objInfraException->adicionarValidacao($strDescricao, $strAtributoValidacao);
+                    }
 
-                if (!empty($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()) && empty($objPenRelHipoteseLegalEnvioRN->getIdHipoteseLegalPEN($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()))) {
-                    $objHipoteseLegalDTO = new HipoteseLegalDTO();
-                    $objHipoteseLegalDTO->setNumIdHipoteseLegal($objDocumentoDTO->getNumIdHipoteseLegalProtocolo());
-                    $objHipoteseLegalDTO->retStrNome();
-                    $objHipoteseLegalRN = new HipoteseLegalRN();
-                    $dados = $objHipoteseLegalRN->consultar($objHipoteseLegalDTO);
-                    $objInfraException->adicionarValidacao('Hipótese legal "'.$dados->getStrNome().'" do documento '.$objDocumentoDTO->getStrNomeSerie(). ' ' . $objDocumentoDTO->getStrProtocoloDocumentoFormatado() .' não mapeada', $strAtributoValidacao);
+                    if (!empty($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()) && empty($objPenRelHipoteseLegalEnvioRN->getIdHipoteseLegalPEN($objDocumentoDTO->getNumIdHipoteseLegalProtocolo()))) {
+                        $objHipoteseLegalDTO = new HipoteseLegalDTO();
+                        $objHipoteseLegalDTO->setNumIdHipoteseLegal($objDocumentoDTO->getNumIdHipoteseLegalProtocolo());
+                        $objHipoteseLegalDTO->retStrNome();
+                        $objHipoteseLegalRN = new HipoteseLegalRN();
+                        $dados = $objHipoteseLegalRN->consultar($objHipoteseLegalDTO);
+                        $objInfraException->adicionarValidacao('Hipótese legal "'.$dados->getStrNome().'" do documento '.$objDocumentoDTO->getStrNomeSerie(). ' ' . $objDocumentoDTO->getStrProtocoloDocumentoFormatado() .' não mapeada', $strAtributoValidacao);
+                    }
                 }
             }
         }
@@ -2034,7 +2036,11 @@ class ExpedirProcedimentoRN extends InfraRN {
                 $objHipoteseLegalDTO->retStrNome();
                 $objHipoteseLegalRN = new HipoteseLegalRN();
                 $dados = $objHipoteseLegalRN->consultar($objHipoteseLegalDTO);
-                $objInfraException->adicionarValidacao('Hipótese legal "' . $dados->getStrNome() . '" do processo ' . $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado() . ' não mapeada', $strAtributoValidacao);
+                if (!empty($dados)) {
+                    $objInfraException->adicionarValidacao('Hipótese legal "' . $dados->getStrNome() . '" do processo ' . $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado() . ' não mapeada', $strAtributoValidacao);
+                }else{
+                    $objInfraException->adicionarValidacao('Verificar se a Hipótese legal do processo ' . $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado() . ' está ativa.', $strAtributoValidacao);
+                }
             }
         }
     }

--- a/src/rn/PenRelHipoteseLegalRN.php
+++ b/src/rn/PenRelHipoteseLegalRN.php
@@ -33,6 +33,14 @@ abstract class PenRelHipoteseLegalRN extends InfraRN {
     protected function alterarInternoControlado(PenRelHipoteseLegalDTO $objDTO)
     {
         try {
+
+            //Regras de Negocio
+            $objInfraException = new InfraException();
+            $this->validarCadastroExistente($objDTO, $objInfraException);
+            if($objInfraException->contemValidacoes()){
+                return $objInfraException;
+            }
+
             $objBD = new GenericoBD($this->inicializarObjInfraIBanco());
             return $objBD->alterar($objDTO);
         }
@@ -44,6 +52,14 @@ abstract class PenRelHipoteseLegalRN extends InfraRN {
     protected function cadastrarInternoControlado(PenRelHipoteseLegalDTO $objDTO)
     {
         try {
+
+            //Regras de Negocio
+            $objInfraException = new InfraException();
+            $this->validarCadastroExistente($objDTO, $objInfraException);
+            if($objInfraException->contemValidacoes()){
+                return $objInfraException;
+            }
+
             $objBD = new GenericoBD($this->inicializarObjInfraIBanco());
             return $objBD->cadastrar($objDTO);
         }
@@ -62,6 +78,20 @@ abstract class PenRelHipoteseLegalRN extends InfraRN {
             throw new InfraException('Erro ao excluir mapeamento de hipóteses legais', $e);
         }
     }
+
+    private function validarCadastroExistente(PenRelHipoteseLegalDTO $objDTO, InfraException $objInfraException){
+
+        $objPenRelHipoteseLegalDTO = new PenRelHipoteseLegalDTO();
+        $objPenRelHipoteseLegalDTO->setNumIdHipoteseLegal($objDTO->getNumIdHipoteseLegal());
+        $objPenRelHipoteseLegalDTO->setStrTipo($objDTO->getStrTipo());
+        $objPenRelHipoteseLegalDTO->retDblIdMap();
+
+        $ret = $this->consultarInterno($objPenRelHipoteseLegalDTO);
+
+        if(!empty($ret)){
+            $objInfraException->adicionarValidacao('já cadastrada.');
+        }
+    }    
 
     public function getIdBarramentoEmUso(PenRelHipoteseLegalDTO $objFiltroDTO, $strTipo = 'E'){
 

--- a/src/rn/VerificadorInstalacaoRN.php
+++ b/src/rn/VerificadorInstalacaoRN.php
@@ -30,7 +30,7 @@ require_once DIR_SEI_WEB . '/SEI.php';
 class VerificadorInstalacaoRN extends InfraRN
 {
     // A partir da versão 2.0.0, o módulo de integração do SEI com o PEN não será mais compatível com o SEI 3.0.X
-    const COMPATIBILIDADE_MODULO_SEI = array('3.1.0', '3.1.1', '3.1.2', '3.1.3', '3.1.4', '3.1.5', '3.1.6');
+    const COMPATIBILIDADE_MODULO_SEI = array('3.1.0', '3.1.1', '3.1.2', '3.1.3', '3.1.4', '3.1.5', '3.1.6', '3.1.7');
 
     public function __construct() {
         parent::__construct();

--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -99,6 +99,7 @@ class PenAtualizarSeiRN extends PenAtualizadorRN {
                 case '2.1.2': $this->instalarV2103();
                 case '2.1.3': $this->instalarV2104();
                 case '2.1.4': $this->instalarV2105();
+                case '2.1.5': $this->instalarV2106();
                     break;
                 default:
                 $this->finalizar('VERSAO DO MÓDULO JÁ CONSTA COMO ATUALIZADA');
@@ -2090,6 +2091,11 @@ class PenAtualizarSeiRN extends PenAtualizadorRN {
     protected function instalarV2105()
     {
         $this->atualizarNumeroVersao("2.1.5");
+    }
+
+    protected function instalarV2106()
+    {
+        $this->atualizarNumeroVersao("2.1.6");
     }
 }
 

--- a/src/scripts/sip_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sip_atualizar_versao_modulo_pen.php
@@ -129,6 +129,7 @@ class PenAtualizarSipRN extends InfraRN {
                 case '2.1.2': $this->instalarV2103();
                 case '2.1.3': $this->instalarV2104();
                 case '2.1.4': $this->instalarV2105();
+                case '2.1.5': $this->instalarV2106();
                     break;
 
                 default:
@@ -1375,6 +1376,14 @@ class PenAtualizarSipRN extends InfraRN {
     protected function instalarV2105()
     {
 	    $this->atualizarNumeroVersao("2.1.5");
+    }
+
+    /**
+     * Instala/Atualiza os módulo PEN para versão 2.1.6
+     */
+    protected function instalarV2106()
+    {
+	    $this->atualizarNumeroVersao("2.1.6");
     }
 }
 

--- a/tests/funcional/phpunit.xml
+++ b/tests/funcional/phpunit.xml
@@ -39,12 +39,16 @@
     <const name="CONTEXTO_ORGAO_A_USUARIO_LOGIN" value="teste" />
     <const name="CONTEXTO_ORGAO_A_USUARIO_SENHA" value="teste" />    
     <const name="CONTEXTO_ORGAO_A_TIPO_PROCESSO" value="Arrecadação: Cobrança" />
+    <const name="CONTEXTO_ORGAO_A_TIPO_PROCESSO_SIGILOSO" value="Acesso à Informação: Demanda do e-SIC" />
     <const name="CONTEXTO_ORGAO_A_TIPO_DOCUMENTO" value="Ofício" />
+    <const name="CONTEXTO_ORGAO_A_TIPO_PROCESSO_SIGILOSO" value="Acesso à Informação: Demanda do e-SIC" />
     <const name="CONTEXTO_ORGAO_A_TIPO_DOCUMENTO_NAO_MAPEADO" value="Voto" />
     <const name="CONTEXTO_ORGAO_A_HIPOTESE_RESTRICAO" value="Documento Preparatório (Art. 7º, § 3º, da Lei nº 12.527/2011)" />
     <const name="CONTEXTO_ORGAO_A_HIPOTESE_RESTRICAO_NAO_MAPEADO" value="Informação Pessoal (Art. 31 da Lei nº 12.527/2011)" />
     <const name="CONTEXTO_ORGAO_A_CARGO_ASSINATURA" value="Assessor(a)" />       
     <const name="CONTEXTO_ORGAO_A_HIPOTESE_RESTRICAO_PADRAO" value="Controle Interno (Art. 26, § 3º, da Lei nº 10.180/2001)" />
+    <const name="CONTEXTO_ORGAO_A_HIPOTESE_RESTRICAO_INATIVA" value="Situação Econômico-Financeira de Sujeito Passivo (Art. 198, caput, da Lei nº 5.172/1966 - CTN)" />
+    <const name="CONTEXTO_ORGAO_A_HIPOTESE_SIGILOSO" value="Sigilo do Inquérito Policial (Art. 20 do Código de Processo Penal)" />
     <const name="CONTEXTO_ORGAO_A_LOCALIZACAO_CERTIFICADO_DIGITAL" value="/../assets/config/certificado_org1.pem" />
     <const name="CONTEXTO_ORGAO_A_SENHA_CERTIFICADO_DIGITAL" value="" />
     <const name="CONTEXTO_ORGAO_A_DB_SEI_DSN" value="mysql:host=127.0.0.1;port=33061;dbname=sei;" />   
@@ -70,10 +74,14 @@
     <const name="CONTEXTO_ORGAO_B_SIGLA_UNIDADE_SECUNDARIA" value="" />
     <const name="CONTEXTO_ORGAO_B_SIGLA_UNIDADE_SECUNDARIA_HIERARQUIA" value="" />
     <const name="CONTEXTO_ORGAO_B_TIPO_PROCESSO" value="Arrecadação: Cobrança" />    
+    <const name="CONTEXTO_ORGAO_B_TIPO_PROCESSO_SIGILOSO" value="Acesso à Informação: Demanda do e-SIC" /> 
     <const name="CONTEXTO_ORGAO_B_TIPO_DOCUMENTO" value="Ofício" />
-    <const name="CONTEXTO_ORGAO_B_TIPO_DOCUMENTO_NAO_MAPEADO" value="Nota" />           
+    <const name="CONTEXTO_ORGAO_B_TIPO_DOCUMENTO_NAO_MAPEADO" value="Nota" />  
+    <const name="CONTEXTO_ORGAO_B_TIPO_PROCESSO_SIGILOSO" value="Acesso à Informação: Demanda do e-SIC" />          
     <const name="CONTEXTO_ORGAO_B_HIPOTESE_RESTRICAO" value="Documento Preparatório (Art. 7º, § 3º, da Lei nº 12.527/2011)" />    
     <const name="CONTEXTO_ORGAO_B_HIPOTESE_RESTRICAO_NAO_MAPEADO" value="Informação Pessoal (Art. 31 da Lei nº 12.527/2011)" />
+    <const name="CONTEXTO_ORGAO_B_HIPOTESE_RESTRICAO_INATIVA" value="Situação Econômico-Financeira de Sujeito Passivo (Art. 198, caput, da Lei nº 5.172/1966 - CTN)" />
+    <const name="CONTEXTO_ORGAO_B_HIPOTESE_SIGILOSO" value="Sigilo do Inquérito Policial (Art. 20 do Código de Processo Penal)" />    
     <const name="CONTEXTO_ORGAO_B_CARGO_ASSINATURA" value="Assessor(a)" />       
     <const name="CONTEXTO_ORGAO_B_HIPOTESE_RESTRICAO_PADRAO" value="Controle Interno (Art. 26, § 3º, da Lei nº 10.180/2001)" />
     <const name="CONTEXTO_ORGAO_B_LOCALIZACAO_CERTIFICADO_DIGITAL" value="/../assets/config/certificado_org2.pem" />

--- a/tests/funcional/src/paginas/PaginaIncluirDocumento.php
+++ b/tests/funcional/src/paginas/PaginaIncluirDocumento.php
@@ -108,8 +108,8 @@ class PaginaIncluirDocumento extends PaginaTeste
 				$input = $this->test->byId("optSigiloso")->click();
 				$select = $this->test->select($this->test->byId('selHipoteseLegal'));
 				$select->selectOptionByLabel($strHipoteseLegal);
-				$select = $this->test->select($this->test->byId('selGrauSigilo'));
-				$select->selectOptionByLabel($strGrauSigilo);
+				/*$select = $this->test->select($this->test->byId('selGrauSigilo'));
+				$select->selectOptionByLabel($strGrauSigilo);*/
 	    	}
     	}
     }

--- a/tests/funcional/tests/CenarioBaseTestCase.php
+++ b/tests/funcional/tests/CenarioBaseTestCase.php
@@ -87,6 +87,9 @@ class CenarioBaseTestCase extends Selenium2TestCase
         // Habilitação da extensão docx
         $bancoOrgaoA->execute("update arquivo_extensao set sin_ativo=? where extensao=?", array('S', 'docx'));
 
+        // Ativar hipótese legal Situação Econômico-Financeira de Sujeito Passivo
+        $bancoOrgaoA->execute("update hipotese_legal set sin_ativo=? where id_hipotese_legal=?", array('S', '18'));
+
 
         /***************** CONFIGURAÇÃO PRELIMINAR DO ÓRGÃO 2 *****************/
         $parametrosOrgaoB = new ParameterUtils(CONTEXTO_ORGAO_B);
@@ -108,6 +111,9 @@ class CenarioBaseTestCase extends Selenium2TestCase
         $bancoOrgaoB->execute("delete from md_pen_rel_doc_map_recebido where id_serie = ?", array($serieNaoMapeadaOrigem[0]["ID_SERIE"]));
         $bancoOrgaoB->execute("insert into md_pen_rel_hipotese_legal(id_mapeamento, id_hipotese_legal, id_hipotese_legal_pen, tipo, sin_ativo) values (?, ?, ?, ?, ?);", array(4, 3, 3, 'E', 'S'));
         $bancoOrgaoB->execute("insert into md_pen_rel_hipotese_legal(id_mapeamento, id_hipotese_legal, id_hipotese_legal_pen, tipo, sin_ativo) values (?, ?, ?, ?, ?);", array(5, 3, 3, 'R', 'S'));
+
+        // Ativa hipótese legal Situação Econômico-Financeira de Sujeito Passivo
+        $bancoOrgaoB->execute("update hipotese_legal set sin_ativo=? where id_hipotese_legal=?", array('S', '18'));
     }
 
     public static function tearDownAfterClass(): void
@@ -163,6 +169,7 @@ class CenarioBaseTestCase extends Selenium2TestCase
             'LOGIN' => constant($nomeContexto . '_USUARIO_LOGIN'),
             'SENHA' => constant($nomeContexto . '_USUARIO_SENHA'),
             'TIPO_PROCESSO' => constant($nomeContexto . '_TIPO_PROCESSO'),
+            'TIPO_PROCESSO_SIGILOSO' => constant($nomeContexto . '_TIPO_PROCESSO_SIGILOSO'),
             'TIPO_DOCUMENTO' => constant($nomeContexto . '_TIPO_DOCUMENTO'),
             'TIPO_DOCUMENTO_NAO_MAPEADO' => constant($nomeContexto . '_TIPO_DOCUMENTO_NAO_MAPEADO'),
             'CARGO_ASSINATURA' => constant($nomeContexto . '_CARGO_ASSINATURA'),
@@ -174,6 +181,8 @@ class CenarioBaseTestCase extends Selenium2TestCase
             'HIPOTESE_RESTRICAO_NAO_MAPEADO' => constant($nomeContexto . '_HIPOTESE_RESTRICAO_NAO_MAPEADO'),
             'REP_ESTRUTURAS' => constant($nomeContexto . '_REP_ESTRUTURAS'),
             'HIPOTESE_RESTRICAO_PADRAO' => constant($nomeContexto . '_HIPOTESE_RESTRICAO_PADRAO'),
+            'HIPOTESE_RESTRICAO_INATIVA' => constant($nomeContexto . '_HIPOTESE_RESTRICAO_INATIVA'),
+            'HIPOTESE_SIGILOSO' => constant($nomeContexto . '_HIPOTESE_SIGILOSO'),
             'LOCALIZACAO_CERTIFICADO_DIGITAL' => realpath(__DIR__ . constant($nomeContexto . '_LOCALIZACAO_CERTIFICADO_DIGITAL')),
             'SENHA_CERTIFICADO_DIGITAL' => constant($nomeContexto . '_SENHA_CERTIFICADO_DIGITAL'),
             'ID_REP_ESTRUTURAS' => constant($nomeContexto . '_ID_REP_ESTRUTURAS'),

--- a/tests/funcional/tests/TramiteProcessoRestritoComDocumentoRestritoCanceladoComHipoteseInativaTest.php
+++ b/tests/funcional/tests/TramiteProcessoRestritoComDocumentoRestritoCanceladoComHipoteseInativaTest.php
@@ -1,0 +1,151 @@
+<?php
+
+class TramiteProcessoRestritoComDocumentoRestritoCanceladoComHipoteseInativaTest extends CenarioBaseTestCase
+{
+    public static $remetente;
+    public static $destinatario;
+    public static $processoTeste;
+    public static $documentoTeste1;
+    public static $documentoTeste2;
+    public static $protocoloTeste;
+
+    /**
+     * Teste de trâmite externo de processo com documentos restritos
+     *
+     * @group envio
+     *
+     * @return void
+     */
+    public function test_tramitar_processo_restrivo_com_documento_restrito_cancelado_hipotese_inativa()
+    {
+        // Configuração do dados para teste do cenário
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+        self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste1 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+        self::$documentoTeste2 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        // Configuração de processo restrito
+        self::$processoTeste["RESTRICAO"] = PaginaIniciarProcesso::STA_NIVEL_ACESSO_RESTRITO;
+        self::$processoTeste["HIPOTESE_LEGAL"] = self::$remetente["HIPOTESE_RESTRICAO"];        
+
+        // Acessar sistema do this->REMETENTE do processo
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        // Cadastrar novo processo de teste
+        self::$protocoloTeste = $this->cadastrarProcesso(self::$processoTeste);
+
+        // Configuração de documento restrito
+        self::$documentoTeste1["RESTRICAO"] = PaginaIncluirDocumento::STA_NIVEL_ACESSO_RESTRITO;
+        self::$documentoTeste1["HIPOTESE_LEGAL"] = self::$remetente["HIPOTESE_RESTRICAO"];
+
+        // Incluir Documentos no Processo
+        $this->cadastrarDocumentoInterno(self::$documentoTeste1);
+
+        // Assinar documento interno criado anteriormente
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);        
+
+        // Configuração de documento restrito
+        self::$documentoTeste2["RESTRICAO"] = PaginaIncluirDocumento::STA_NIVEL_ACESSO_RESTRITO;
+        self::$documentoTeste2["HIPOTESE_LEGAL"] = self::$remetente["HIPOTESE_RESTRICAO_INATIVA"];
+
+        // Incluir Documentos no Processo
+        $this->cadastrarDocumentoInterno(self::$documentoTeste2);
+
+        // Assinar documento interno criado anteriormente
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);
+
+        $this->paginaDocumento->navegarParaCancelarDocumento();
+        $this->paginaCancelarDocumento->cancelar("Motivo de teste"); 
+
+        // Inativa hipótese legal Situação Econômico-Financeira de Sujeito Passivo
+        $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);
+        $bancoOrgaoA->execute("update hipotese_legal set sin_ativo=? where id_hipotese_legal=?", array('N', '18'));
+
+        // Trâmitar Externamento processo para órgão/unidade destinatária
+        $this->tramitarProcessoExternamente(
+                self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
+                self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+    }
+
+
+    /**
+     * Teste de verificação do correto envio do processo no sistema remetente
+     *
+     * @group verificacao_envio
+     *
+     * @depends test_tramitar_processo_restrivo_com_documento_restrito_cancelado_hipotese_inativa
+     *
+     * @return void
+     */
+    public function test_verificar_origem_processo_com_documento_restrito_cancelado_hipotese_inativa()
+    {
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        // 6 - Verificar se situação atual do processo está como bloqueado
+        $this->waitUntil(function($testCase) use (&$orgaosDiferentes) {
+            sleep(5);
+            $testCase->refresh();
+            $paginaProcesso = new PaginaProcesso($testCase);
+            $testCase->assertStringNotContainsString(utf8_encode("Processo em trâmite externo para "), $paginaProcesso->informacao());
+            $testCase->assertFalse($paginaProcesso->processoAberto());
+            $testCase->assertEquals($orgaosDiferentes, $paginaProcesso->processoBloqueado());
+            return true;
+        }, PEN_WAIT_TIMEOUT);
+
+        // 7 - Validar se recibo de trâmite foi armazenado para o processo (envio e conclusão)
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
+        $this->validarRecibosTramite($mensagemRecibo, true, true);
+
+        // 8 - Validar histórico de trâmite do processo
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
+
+        // 9 - Verificar se processo está na lista de Processos Tramitados Externamente
+        $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
+    }
+
+
+    /**
+     * Teste de verificação do correto recebimento do processo contendo um documento cancelado com hipótese legal inativa
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_tramitar_processo_restrivo_com_documento_restrito_cancelado_hipotese_inativa
+     *
+     * @return void
+     */
+    public function test_verificar_destino_processo_com_documento_restrito_cancelado_hipotese_inativa()
+    {
+        $strProtocoloTeste = self::$protocoloTeste;
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$destinatario['URL'], self::$destinatario['SIGLA_UNIDADE'], self::$destinatario['LOGIN'], self::$destinatario['SENHA']);
+
+        // 11 - Abrir protocolo na tela de controle de processos
+        $this->abrirProcesso(self::$protocoloTeste);
+        $listaDocumentos = $this->paginaProcesso->listarDocumentos();
+
+        // 12 - Validar dados  do processo
+        $strTipoProcesso = utf8_encode("Tipo de processo no órgão de origem: ");
+        $strTipoProcesso .= self::$processoTeste['TIPO_PROCESSO'];
+        self::$processoTeste['OBSERVACOES'] = $orgaosDiferentes ? $strTipoProcesso : null;
+        $this->validarDadosProcesso(self::$processoTeste['DESCRICAO'], self::$processoTeste['RESTRICAO'], self::$processoTeste['OBSERVACOES'], array(self::$processoTeste['INTERESSADOS']));
+
+        // 13 - Verificar recibos de trâmite
+        $this->validarRecibosTramite("Recebimento do Processo $strProtocoloTeste", false, true);
+
+        // 14 - Validar dados do documento
+        $this->assertTrue(count($listaDocumentos) == 2);
+        $this->validarDadosDocumento($listaDocumentos[0], self::$documentoTeste1, self::$destinatario);
+        
+        // Ativa hipótese legal Situação Econômico-Financeira de Sujeito Passivo
+        $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);
+        $bancoOrgaoA->execute("update hipotese_legal set sin_ativo=? where id_hipotese_legal=?", array('S', '18'));
+
+    }
+}

--- a/tests/funcional/tests/TramiteProcessoRestritoComDocumentoRestritoCanceladoComHipoteseInativaTest.php
+++ b/tests/funcional/tests/TramiteProcessoRestritoComDocumentoRestritoCanceladoComHipoteseInativaTest.php
@@ -10,7 +10,7 @@ class TramiteProcessoRestritoComDocumentoRestritoCanceladoComHipoteseInativaTest
     public static $protocoloTeste;
 
     /**
-     * Teste de trâmite externo de processo com documentos restritos
+     * Teste de trâmite externo de processo com documento restrito com hipótese legal inativa cancelado
      *
      * @group envio
      *
@@ -111,7 +111,7 @@ class TramiteProcessoRestritoComDocumentoRestritoCanceladoComHipoteseInativaTest
 
 
     /**
-     * Teste de verificação do correto recebimento do processo contendo um documento cancelado com hipótese legal inativa
+     * Teste de verificação do correto recebimento do processo contendo um documento com hipótese legal inativa cancelado
      *
      * @group verificacao_recebimento
      *

--- a/tests/funcional/tests/TramiteProcessoRestritoComDocumentoSigilosoCanceladoTest.php
+++ b/tests/funcional/tests/TramiteProcessoRestritoComDocumentoSigilosoCanceladoTest.php
@@ -1,0 +1,156 @@
+<?php
+
+class TramiteProcessoRestritoComDocumentoSigilosoCanceladoTest extends CenarioBaseTestCase
+{
+    public static $remetente;
+    public static $destinatario;
+    public static $processoTeste;
+    public static $documentoTeste1;
+    public static $documentoTeste2;
+    public static $protocoloTeste;
+
+    /**
+     * Teste de trâmite externo de processo com documentos restritos
+     *
+     * @group envio
+     *
+     * @return void
+     */
+    public function test_tramitar_processo_restrivo_com_documento_sigiloso_cancelado()
+    {
+        // Configuração do dados para teste do cenário
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+        self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste1 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+        self::$documentoTeste2 = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
+
+        // Processo Acesso à Informação: Demanda do e-SIC - Sigiloso
+        $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);
+        $bancoOrgaoA->execute("update nivel_acesso_permitido set sta_nivel_acesso=? where id_tipo_procedimento=? and sta_nivel_acesso=?", array('2', '100000381', '0'));
+
+        // hipótese legal Sigilo do Inquérito Policial - Sigiloso
+        $bancoOrgaoA->execute("update hipotese_legal set sta_nivel_acesso=? where id_hipotese_legal=?", array('2', '17'));
+
+        // Processo Acesso à Informação: Demanda do e-SIC - Sigiloso
+        $bancoOrgaoB = new DatabaseUtils(CONTEXTO_ORGAO_B);
+        $bancoOrgaoB->execute("update nivel_acesso_permitido set sta_nivel_acesso=? where id_tipo_procedimento=? and sta_nivel_acesso=?", array('2', '100000381', '0'));
+
+        // hipótese legal Sigilo do Inquérito Policial - Sigiloso
+        $bancoOrgaoB->execute("update hipotese_legal set sta_nivel_acesso=? where id_hipotese_legal=?", array('2', '17'));
+
+        // Configuração de processo restrito
+        self::$processoTeste["RESTRICAO"] = PaginaIniciarProcesso::STA_NIVEL_ACESSO_RESTRITO;
+        self::$processoTeste["HIPOTESE_LEGAL"] = self::$remetente["HIPOTESE_RESTRICAO"];
+        self::$processoTeste["TIPO_PROCESSO"] = self::$remetente["TIPO_PROCESSO_SIGILOSO"];
+
+        // Acessar sistema do this->REMETENTE do processo
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        // Cadastrar novo processo de teste
+        self::$protocoloTeste = $this->cadastrarProcesso(self::$processoTeste);
+
+        // Configuração de documento restrito
+        self::$documentoTeste1["RESTRICAO"] = PaginaIncluirDocumento::STA_NIVEL_ACESSO_RESTRITO;
+        self::$documentoTeste1["HIPOTESE_LEGAL"] = self::$remetente["HIPOTESE_RESTRICAO"];
+
+        // Incluir Documentos no Processo
+        $this->cadastrarDocumentoInterno(self::$documentoTeste1);        
+
+        // Assinar documento interno criado anteriormente
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);
+
+        // Configuração de documento sigiloso
+        self::$documentoTeste2["RESTRICAO"] = PaginaIncluirDocumento::STA_NIVEL_ACESSO_SIGILOSO;
+        self::$documentoTeste2["HIPOTESE_LEGAL"] = self::$remetente["HIPOTESE_SIGILOSO"];
+
+        $this->cadastrarDocumentoInterno(self::$documentoTeste2);
+
+        // Assinar documento interno criado anteriormente
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);
+
+        $this->paginaDocumento->navegarParaCancelarDocumento();
+        $this->paginaCancelarDocumento->cancelar("Motivo de teste"); 
+
+        // Trâmitar Externamento processo para órgão/unidade destinatária
+        $this->tramitarProcessoExternamente(
+                self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
+                self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+    }
+
+
+    /**
+     * Teste de verificação do correto envio do processo no sistema remetente
+     *
+     * @group verificacao_envio
+     *
+     * @depends test_tramitar_processo_restrivo_com_documento_sigiloso_cancelado
+     *
+     * @return void
+     */
+    public function test_verificar_origem_processo_com_documento_sigiloso_cancelado()
+    {
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        // 6 - Verificar se situação atual do processo está como bloqueado
+        $this->waitUntil(function($testCase) use (&$orgaosDiferentes) {
+            sleep(5);
+            $testCase->refresh();
+            $paginaProcesso = new PaginaProcesso($testCase);
+            $testCase->assertStringNotContainsString(utf8_encode("Processo em trâmite externo para "), $paginaProcesso->informacao());
+            $testCase->assertFalse($paginaProcesso->processoAberto());
+            $testCase->assertEquals($orgaosDiferentes, $paginaProcesso->processoBloqueado());
+            return true;
+        }, PEN_WAIT_TIMEOUT);
+
+        // 7 - Validar se recibo de trâmite foi armazenado para o processo (envio e conclusão)
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
+        $this->validarRecibosTramite($mensagemRecibo, true, true);
+
+        // 8 - Validar histórico de trâmite do processo
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
+
+        // 9 - Verificar se processo está na lista de Processos Tramitados Externamente
+        $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
+    }
+
+
+    /**
+     * Teste de verificação do correto recebimento do processo contendo um documento cancelado com hipótese legal inativa
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_tramitar_processo_restrivo_com_documento_sigiloso_cancelado
+     *
+     * @return void
+     */
+    public function test_verificar_destino_processo_com_documento_sigiloso_cancelado()
+    {
+        $strProtocoloTeste = self::$protocoloTeste;
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$destinatario['URL'], self::$destinatario['SIGLA_UNIDADE'], self::$destinatario['LOGIN'], self::$destinatario['SENHA']);
+
+        // 11 - Abrir protocolo na tela de controle de processos
+        $this->abrirProcesso(self::$protocoloTeste);
+        $listaDocumentos = $this->paginaProcesso->listarDocumentos();
+
+        // 12 - Validar dados  do processo
+        $strTipoProcesso = utf8_encode("Tipo de processo no órgão de origem: ");
+        $strTipoProcesso .= self::$processoTeste['TIPO_PROCESSO'];
+        self::$processoTeste['OBSERVACOES'] = $orgaosDiferentes ? $strTipoProcesso : null;
+        $this->validarDadosProcesso(self::$processoTeste['DESCRICAO'], self::$processoTeste['RESTRICAO'], self::$processoTeste['OBSERVACOES'], array(self::$processoTeste['INTERESSADOS']));
+
+        // 13 - Verificar recibos de trâmite
+        $this->validarRecibosTramite("Recebimento do Processo $strProtocoloTeste", false, true);
+
+        // 14 - Validar dados do documento
+        $this->assertTrue(count($listaDocumentos) == 2);
+        $this->validarDadosDocumento($listaDocumentos[0], self::$documentoTeste1, self::$destinatario);
+    }
+}

--- a/tests/funcional/tests/TramiteProcessoRestritoComDocumentoSigilosoCanceladoTest.php
+++ b/tests/funcional/tests/TramiteProcessoRestritoComDocumentoSigilosoCanceladoTest.php
@@ -10,7 +10,7 @@ class TramiteProcessoRestritoComDocumentoSigilosoCanceladoTest extends CenarioBa
     public static $protocoloTeste;
 
     /**
-     * Teste de trâmite externo de processo com documentos restritos
+     * Teste de trâmite externo de processo com documento sigiloso cancelado
      *
      * @group envio
      *
@@ -121,7 +121,7 @@ class TramiteProcessoRestritoComDocumentoSigilosoCanceladoTest extends CenarioBa
 
 
     /**
-     * Teste de verificação do correto recebimento do processo contendo um documento cancelado com hipótese legal inativa
+     * Teste de verificação do correto recebimento do processo contendo um documento sigiloso cancelado
      *
      * @group verificacao_recebimento
      *


### PR DESCRIPTION
Correção de erro no tramite de documento restrito ou sigiloso cancelado.

Criação de validação para não permitir cadastro duplicado de envio ou recebimento no mapeamento de hipótese legal.

Closes #64, Closes #74, Closes #76