### PR TITLE
Ajuste para não duplicação de NUP no SEI4

### DIFF
--- a/src/rn/ReceberProcedimentoRN.php
+++ b/src/rn/ReceberProcedimentoRN.php
@@ -1067,6 +1067,8 @@ class ReceberProcedimentoRN extends InfraRN
             $objProcedimentoDTO->getObjProtocoloDTO()->setStrProtocoloFormatado($strNumProtocoloDocumentoAvulso);
         }
 
+        $objInfraParametro = new InfraParametro($this->getObjInfraIBanco());
+        $objInfraParametro->setValor('SEI_FEDERACAO_NUMERO_PROCESSO', 0);
         $objProcedimentoDTOGerado = $objProcedimentoRN->gerarRN0156($objProcedimentoDTO);
 
         $objProcedimentoDTO->setDblIdProcedimento($objProcedimentoDTOGerado->getDblIdProcedimento());


### PR DESCRIPTION
Com o lançamento da versão 4 do SEI, o módulo não bloqueia a criação de novo NUP nos casos de já existir numeração igual no órgão.

Closes #120