### PR TITLE
fix: botao de bloco aparece apenas quando existe algum bloco aberto

### DIFF
--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -55,7 +55,20 @@ class PENIntegracao extends SeiIntegracao
 
     $bolAcaoIncluirProcessoEmBloco = $objSessaoSEI->verificarPermissao('pen_incluir_processo_em_bloco_tramite');
 
-    if ($bolAcaoIncluirProcessoEmBloco) {
+    $bolBlocoAbertoUnidade = false; 
+    $objTramiteEmBlocoDTO = new TramiteEmBlocoDTO();
+    $objTramiteEmBlocoDTO->setStrStaEstado(TramiteEmBlocoRN::$TE_ABERTO);
+    $objTramiteEmBlocoDTO->setNumIdUnidade($objSessaoSEI->getNumIdUnidadeAtual());
+    $objTramiteEmBlocoDTO->retNumId();
+    $objTramiteEmBlocoDTO->retNumIdUnidade();
+    $objTramiteEmBlocoDTO->retStrDescricao();
+  
+    $objTramiteEmBlocoRN = new TramiteEmBlocoRN();
+    if (count($objTramiteEmBlocoRN->listar($objTramiteEmBlocoDTO)) > 0) {
+      $bolBlocoAbertoUnidade = true;
+    }
+
+    if ($bolAcaoIncluirProcessoEmBloco && $bolBlocoAbertoUnidade) {
       $objPaginaSEI = PaginaSEI::getInstance();
 
       $objAtividadeDTO = new AtividadeDTO();


### PR DESCRIPTION
- No controle de processo botão só aparece quando há blocos abertos na unidade
closes #536 