### PR TITLE
feat: reload pagina processo apos inclusao/remocao de processo em bloco

### DIFF
--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -172,23 +172,9 @@ class PENIntegracao extends SeiIntegracao
       $bolUnidadeMapeada = true;
     }
     //Apresenta o botão de expedir processo
-    if ($bolUnidadeMapeada && $bolFlagAberto && $bolAcaoExpedirProcesso && $bolProcessoEstadoNormal && $objProcedimentoDTO->getStrStaNivelAcessoGlobalProtocolo() != ProtocoloRN::$NA_SIGILOSO) {
+    if ($bolUnidadeMapeada && !$bolProcessoEmBloco && $bolFlagAberto && $bolAcaoExpedirProcesso && $bolProcessoEstadoNormal && $objProcedimentoDTO->getStrStaNivelAcessoGlobalProtocolo() != ProtocoloRN::$NA_SIGILOSO) {
         $numTabBotao = $objPaginaSEI->getProxTabBarraComandosSuperior();
         $strAcoesProcedimento .= '<a id="validar_expedir_processo" href="' . $objPaginaSEI->formatarXHTML($objSessaoSEI->assinarLink('controlador.php?acao=pen_procedimento_expedir&acao_origem=procedimento_visualizar&acao_retorno=arvore_visualizar&id_procedimento=' . $dblIdProcedimento . '&arvore=1')) . '" tabindex="' . $numTabBotao . '" class="botaoSEI"><img class="infraCorBarraSistema" src=' . ProcessoEletronicoINT::getCaminhoIcone("/pen_expedir_procedimento.gif", $this->getDiretorioImagens()) . ' alt="Envio Externo de Processo" title="Envio Externo de Processo" /></a>';
-    }
-
-    //Apresenta o botão da página de recibos
-    if($bolAcaoExpedirProcesso){
-      $objProcessoEletronicoDTO = new ProcessoEletronicoDTO();
-      $objProcessoEletronicoDTO->retDblIdProcedimento();
-      $objProcessoEletronicoDTO->setDblIdProcedimento($dblIdProcedimento);
-      $objProcessoEletronicoRN = new ProcessoEletronicoRN();
-      if($objProcessoEletronicoRN->contar($objProcessoEletronicoDTO) != 0){
-        $numTabBotao = $objPaginaSEI->getProxTabBarraComandosSuperior();
-        $strAcoesProcedimento .= '<a href="' . $objSessaoSEI->assinarLink('controlador.php?acao=pen_procedimento_estado&acao_origem=procedimento_visualizar&acao_retorno=arvore_visualizar&id_procedimento=' . $dblIdProcedimento . '&arvore=1') . '" tabindex="' . $numTabBotao . '" class="botaoSEI">';
-        $strAcoesProcedimento .= '<img class="infraCorBarraSistema" src=' . ProcessoEletronicoINT::getCaminhoIcone("/pen_consultar_recibos.png", $this->getDiretorioImagens()) . ' alt="Consultar Recibos" title="Consultar Recibos"/>';
-        $strAcoesProcedimento .= '</a>';
-      }
     }
 
     //Apresenta o botão de cancelar trâmite
@@ -215,9 +201,23 @@ class PENIntegracao extends SeiIntegracao
     $bolAcaoExcluirProcessoEmBloco = $objSessaoSEI->verificarPermissao('pen_tramita_em_bloco_protocolo_excluir');
     if ($bolUnidadeMapeada && $bolProcessoEmBloco && $bolFlagAberto && $bolAcaoExcluirProcessoEmBloco && $bolProcessoEstadoNormal && $objProcedimentoDTO->getStrStaNivelAcessoGlobalProtocolo() != ProtocoloRN::$NA_SIGILOSO) {
       $numTabBotao = $objPaginaSEI->getProxTabBarraComandosSuperior();
-      $strAcoesProcedimento .= '<a href="' . $objPaginaSEI->formatarXHTML($objSessaoSEI->assinarLink('controlador.php?acao=pen_excluir_processo_em_bloco_tramite&acao_origem=procedimento_visualizar&acao_retorno=arvore_visualizar&id_procedimento=' . $dblIdProcedimento . '&arvore=1')) . '" tabindex="' . $numTabBotao . '" class="botaoSEI"> <img src="'.ProcessoEletronicoINT::getCaminhoIcone("/pen_processo_bloco_excluir.svg", $this->getDiretorioImagens()) .'" title="Remover Processo do Bloco de Trâmite" alt="Remover Processo do Bloco de Trâmite"/></a>';
+      $strAcoesProcedimento .= '<a onclick="return confirm(\\\'Confirma a remoção do processo do bloco de trâmite externo?\\\');" href="' . $objPaginaSEI->formatarXHTML($objSessaoSEI->assinarLink('controlador.php?acao=pen_excluir_processo_em_bloco_tramite&acao_origem=procedimento_visualizar&acao_retorno=arvore_visualizar&id_procedimento=' . $dblIdProcedimento . '&arvore=1')) . '" tabindex="' . $numTabBotao . '" class="botaoSEI"> <img src="'.ProcessoEletronicoINT::getCaminhoIcone("/pen_processo_bloco_excluir.svg", $this->getDiretorioImagens()) .'" title="Remover Processo do Bloco de Trâmite" alt="Remover Processo do Bloco de Trâmite"/></a>';
     }
-    
+
+    //Apresenta o botão da página de recibos
+    if($bolAcaoExpedirProcesso){
+      $objProcessoEletronicoDTO = new ProcessoEletronicoDTO();
+      $objProcessoEletronicoDTO->retDblIdProcedimento();
+      $objProcessoEletronicoDTO->setDblIdProcedimento($dblIdProcedimento);
+      $objProcessoEletronicoRN = new ProcessoEletronicoRN();
+      if($objProcessoEletronicoRN->contar($objProcessoEletronicoDTO) != 0){
+        $numTabBotao = $objPaginaSEI->getProxTabBarraComandosSuperior();
+        $strAcoesProcedimento .= '<a href="' . $objSessaoSEI->assinarLink('controlador.php?acao=pen_procedimento_estado&acao_origem=procedimento_visualizar&acao_retorno=arvore_visualizar&id_procedimento=' . $dblIdProcedimento . '&arvore=1') . '" tabindex="' . $numTabBotao . '" class="botaoSEI">';
+        $strAcoesProcedimento .= '<img class="infraCorBarraSistema" src=' . ProcessoEletronicoINT::getCaminhoIcone("/pen_consultar_recibos.png", $this->getDiretorioImagens()) . ' alt="Consultar Recibos" title="Consultar Recibos"/>';
+        $strAcoesProcedimento .= '</a>';
+      }
+    }
+
     return array($strAcoesProcedimento);
   }
 

--- a/src/pen_tramite_processo_em_bloco_cadastrar.php
+++ b/src/pen_tramite_processo_em_bloco_cadastrar.php
@@ -53,11 +53,17 @@ try {
         $objPenBlocoProcessoRN = new PenBlocoProcessoRN();
         $arrObjPenBlocoProcessoDTO[] = $objPenBlocoProcessoRN->consultar($objPenBlocoProcessoDTO);
         $objPenBlocoProcessoRN->excluir($arrObjPenBlocoProcessoDTO);
-        $objPaginaSEI->adicionarMensagem('Processo "' . $procedimento->getStrProtocoloProcedimentoFormatado() . '" excluido do bloco', InfraPagina::$TIPO_MSG_AVISO);
+        $strMensagem = 'O processo "' . $procedimento->getStrProtocoloProcedimentoFormatado() . '" foi removido com sucesso do bloco de trâmite externo';
       } catch (Exception $e) {
+        $strMensagem = $e->getMessage();
         PaginaSEI::getInstance()->processarExcecao($e);
       }
-      header('Location: ' . SessaoSEI::getInstance()->assinarLink('controlador.php?acao=' . PaginaSEI::getInstance()->getAcaoRetorno() . '&acao_origem=' . $_GET['acao']));
+      ?>
+      <script type="text/javascript">
+        alert('<?= $strMensagem ?>');
+        parent.parent.location.reload();
+      </script>
+      <?php
         exit(0);
       break;
     case 'pen_incluir_processo_em_bloco_tramite':
@@ -109,12 +115,17 @@ try {
           }
 
           $objPenBlocoProcessoDTO = $objPenBlocoProcessoRN->cadastrar($objPenBlocoProcessoDTO);
-
-          $objPaginaSEI->adicionarMensagem('Processo "' . $procedimento->getStrProtocoloProcedimentoFormatado() . '" adicionado ao bloco', InfraPagina::$TIPO_MSG_AVISO);
+          $strMensagem = 'Processo "' . $procedimento->getStrProtocoloProcedimentoFormatado() . '" adicionado ao bloco';
         } catch (Exception $e) {
+          $strMensagem = $e->getMessage();
           PaginaSEI::getInstance()->processarExcecao($e);
         }
-        header('Location: ' . SessaoSEI::getInstance()->assinarLink('controlador.php?acao=' . PaginaSEI::getInstance()->getAcaoRetorno() . '&acao_origem=' . $_GET['acao']));
+        ?>
+        <script type="text/javascript">
+          alert('<?= $strMensagem ?>');
+          parent.parent.location.reload();
+        </script>
+        <?php
         exit(0);
       }
         break;


### PR DESCRIPTION
- Reload pagina processo após inclusão/remoção de processo em bloco
- Reordenação dos ícones na pagina processo
- Envio unitário é removido quando um processo é incluído em um bloco de trâmite
closes #536 
