### PR TITLE
chore: alterar mensagem de exclusão dos processos

### DIFF
--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -2642,7 +2642,7 @@ class ExpedirProcedimentoRN extends InfraRN {
       }
 
       if ($naoAbertoUnidadeAtual == true) {
-        $objInfraException->adicionarValidacao("Esse é um bloco criado em uma versão anterior do módulo. Portanto, é necessário excluir o(s) processo(s) citado(s) do bloco.");
+        $objInfraException->adicionarValidacao("É necessário excluir o(s) processo(s) citado(s) do bloco.");
       }
     }
 


### PR DESCRIPTION
Remover a mensagem "Esse é um bloco criado em uma versão anterior do módulo", pois essa validação está ocorrendo em todos os tipos de blocos, independente versão do modulo o bloco foi criado