### PR TITLE
fix: alterar nome longo na coluna criada na release 3.7.0

### DIFF
--- a/src/dto/PenUnidadeRestricaoDTO.php
+++ b/src/dto/PenUnidadeRestricaoDTO.php
@@ -19,12 +19,12 @@ class PenUnidadeRestricaoDTO extends UnidadeDTO
 
   public function getStrNomeTabela()
   {
-    return 'md_pen_unidade_restricao';
+    return 'md_pen_unid_restricao';
   }
 
   public function getStrNomeSequenciaNativa()
   {
-    return 'md_pen_seq_unidade_restricao';
+    return 'md_pen_seq_unid_restricao';
   }
 
   public function montar()

--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -2642,7 +2642,7 @@ class ExpedirProcedimentoRN extends InfraRN {
       }
 
       if ($naoAbertoUnidadeAtual == true) {
-        $objInfraException->adicionarValidacao("Esse é um bloco criado em uma versão anterior do módulo. Portanto, é necessário excluir o(s) processo(s) citado(s) do bloco.");
+        $objInfraException->adicionarValidacao("É necessário excluir o(s) processo(s) citado(s) do bloco.");
       }
     }
 

--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -2110,7 +2110,7 @@ class PenAtualizarSeiRN extends PenAtualizadorRN
     // Remoção de coluna sin_padrao da tabela md_pen_rel_doc_map_enviado
     $this->logar("CRIANDO TABELA DE CONFIGURACAO PARA RESTRICAO ");
     $objMetaBD->criarTabela(array(
-      'tabela' => 'md_pen_unidade_restricao',
+      'tabela' => 'md_pen_unid_restricao',
       'cols' => array(
         'id' => array($objMetaBD->tipoNumeroGrande(), PenMetaBD::NNULLO),
         'id_unidade' => array($objMetaBD->tipoNumero(), PenMetaBD::NNULLO),
@@ -2131,13 +2131,13 @@ class PenAtualizarSeiRN extends PenAtualizadorRN
     $objInfraSequenciaDTO = new InfraSequenciaDTO();
 
     //Sequência: md_pen_seq_hipotese_legal
-    $rs = BancoSEI::getInstance()->consultarSql('select max(id) as total from md_pen_unidade_restricao');
+    $rs = BancoSEI::getInstance()->consultarSql('select max(id) as total from md_pen_unid_restricao');
     $numMaxId = $rs[0]['total'];
     if ($numMaxId == null) {
       $numMaxId = 0;
     }
-    BancoSEI::getInstance()->criarSequencialNativa('md_pen_seq_unidade_restricao', $numMaxId + 1);
-    $objInfraSequenciaDTO->setStrNome('md_pen_unidade_restricao');
+    BancoSEI::getInstance()->criarSequencialNativa('md_pen_seq_unid_restricao', $numMaxId + 1);
+    $objInfraSequenciaDTO->setStrNome('md_pen_unid_restricao');
     $objInfraSequenciaDTO->retStrNome();
     $arrObjInfraSequenciaDTO = $objInfraSequenciaRN->listar($objInfraSequenciaDTO);
     $objInfraSequenciaRN->excluir($arrObjInfraSequenciaDTO);

--- a/tests_super/funcional/tests/FixtureCenarioBaseTestCase.php
+++ b/tests_super/funcional/tests/FixtureCenarioBaseTestCase.php
@@ -153,16 +153,6 @@ class FixtureCenarioBaseTestCase extends CenarioBaseTestCase
             'IdDocumento' => $protocoloProcessoAnexadoId,
         ]);
     }
-
-    protected function consultarProcessoFixture($protocoloFormatado, $staProtocolo)
-    {
-        $objProtocoloFixture = new ProtocoloFixture();
-        $objProtocoloDTO = $objProtocoloFixture->buscar([
-            'ProtocoloFormatado' => $protocoloFormatado,
-            'StaProtocolo' => $staProtocolo ?: \ProtocoloRN::$TP_DOCUMENTO_GERADO,
-        ]);
-        return $objProtocoloDTO;
-    }
     
     protected function consultarProcessoFixture($protocoloFormatado, $staProtocolo)
     {


### PR DESCRIPTION
Alterar nome da tabela _md_pen_unidade_restricao_ criado no PR #511, para resolver erro de coluna com muito caracteres
Remover metodo duplicado no teste funcional 