### PR TITLE
fix: correção para campo de unidade em restrição de envio

### DIFF
--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -2813,7 +2813,7 @@ class PenAtualizarSeiRN extends PenAtualizadorRN
         'id_unidade_rh' => array($objMetaRestricaoBD->tipoNumeroGrande(), PenMetaBD::NNULLO),
         'id_unidade_restricao' => array($objMetaRestricaoBD->tipoNumeroGrande(), PenMetaBD::NNULLO),
         'nome_unidade_restricao' => array($objMetaRestricaoBD->tipoTextoVariavel(255), $SNULLO),
-        'id_unidade_rh_restricao' => array($objMetaRestricaoBD->tipoNumeroGrande(), PenMetaBD::NNULLO),
+        'id_unidade_rh_restricao' => array($objMetaRestricaoBD->tipoNumeroGrande(), $SNULLO),
         'nome_unidade_rh_restricao' => array($objMetaRestricaoBD->tipoTextoVariavel(255), $SNULLO),
       ),
       'pk' => array('cols' => array('id')),


### PR DESCRIPTION
Campo de id da unidade do Tramita deve receber null quando o mapeamento for apenas para estruturas

Closes #703 