### PR TITLE
fix: corrigir filtro de unidade e tipos de documento

### DIFF
--- a/.github/workflows/testes.yml
+++ b/.github/workflows/testes.yml
@@ -29,18 +29,18 @@ jobs:
         run: | 
              cd sei/src/sei/web/modulos/mod-sei-pen
              make config
-             sed -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 1/155275/' tests_super/funcional/phpunit.xml
-             sed -i 's/INFORME O NOME DA ESTRUTURA UTILIZADO PARA TESTE ORG 1/GIT\_ACTION\_ORG1/' tests_super/funcional/phpunit.xml
-             sed -z -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 1\.1/155277/' tests_super/funcional/phpunit.xml
-             sed -z -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 1\.1/GIT\_ACTION\_FILHA/' tests_super/funcional/phpunit.xml
-             sed -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 2/155276/' tests_super/funcional/phpunit.xml
-             sed -i 's/INFORME O NOME DA ESTRUTURA UTILIZADO PARA TESTE ORG 2/GIT\_ACTION\_ORG2/' tests_super/funcional/phpunit.xml
-             sed -e '/ORG1_CERTIFICADO_SENHA/ s/^#*/#/' -i tests_super/funcional/.env
-             sed -e '/ORG2_CERTIFICADO_SENHA/ s/^#*/#/' -i tests_super/funcional/.env
-             echo "ORG1_CERTIFICADO_SENHA=$GIT_ACTION_SENHA_ORG1" >> tests_super/funcional/.env
-             echo "ORG2_CERTIFICADO_SENHA=$GIT_ACTION_SENHA_ORG2" >> tests_super/funcional/.env
-             echo $CERTIFICADO_ORG1 | base64 --decode > tests_super/funcional/assets/config/certificado_org1.pem
-             echo $CERTIFICADO_ORG2 | base64 --decode > tests_super/funcional/assets/config/certificado_org2.pem
+             sed -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 1/155275/' tests_sei5/funcional/phpunit.xml
+             sed -i 's/INFORME O NOME DA ESTRUTURA UTILIZADO PARA TESTE ORG 1/GIT\_ACTION\_ORG1/' tests_sei5/funcional/phpunit.xml
+             sed -z -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 1\.1/155277/' tests_sei5/funcional/phpunit.xml
+             sed -z -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 1\.1/GIT\_ACTION\_FILHA/' tests_sei5/funcional/phpunit.xml
+             sed -i 's/INFORME O ID DE ESTRUTURA UTILIZADO PARA TESTE ORG 2/155276/' tests_sei5/funcional/phpunit.xml
+             sed -i 's/INFORME O NOME DA ESTRUTURA UTILIZADO PARA TESTE ORG 2/GIT\_ACTION\_ORG2/' tests_sei5/funcional/phpunit.xml
+             sed -e '/ORG1_CERTIFICADO_SENHA/ s/^#*/#/' -i tests_sei5/funcional/.env
+             sed -e '/ORG2_CERTIFICADO_SENHA/ s/^#*/#/' -i tests_sei5/funcional/.env
+             echo "ORG1_CERTIFICADO_SENHA=$GIT_ACTION_SENHA_ORG1" >> tests_sei5/funcional/.env
+             echo "ORG2_CERTIFICADO_SENHA=$GIT_ACTION_SENHA_ORG2" >> tests_sei5/funcional/.env
+             echo $CERTIFICADO_ORG1 | base64 --decode > tests_sei5/funcional/assets/config/certificado_org1.pem
+             echo $CERTIFICADO_ORG2 | base64 --decode > tests_sei5/funcional/assets/config/certificado_org2.pem
              sed -i 's/exec/exec \-T/' Makefile
              make up
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "vendor-dir": "./src/vendor",
+    "vendor-dir": "./vendor",
     "platform": {
       "php": "8.2"
     }
@@ -15,8 +15,11 @@
   },
       
   "require-dev": {
-    "pheromone/phpcs-security-audit": "*" ,
+    "phpunit/phpunit": "*",
+    "squizlabs/php_codesniffer": "*",
+    "mockery/mockery": "^1.5",
+    "pheromone/phpcs-security-audit": "*",
     "phpcompatibility/php-compatibility": "^9.3",
     "rector/rector": "^2.0"
-}
+  }
 }

--- a/src/pen_map_tipo_documento_envio_padrao.php
+++ b/src/pen_map_tipo_documento_envio_padrao.php
@@ -1,6 +1,5 @@
 <?
 try {
-  
   require_once DIR_SEI_WEB.'/SEI.php';
   
   session_start();

--- a/src/rn/EspecieDocumentalRN.php
+++ b/src/rn/EspecieDocumentalRN.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once DIR_SEI_WEB . '/SEI.php';
+
+/**
+ * Regra de negócio para o parâmetros do módulo PEN
+ */
+class EspecieDocumentalRN extends InfraRN
+{
+
+  public function __construct()
+    {
+      parent::__construct();
+  }
+
+  protected function inicializarObjInfraIBanco()
+    {
+      return BancoSEI::getInstance();
+  }
+
+  protected function cadastrarConectado(EspecieDocumentalDTO $objEspecieDocumentalDTO)
+    {
+    try {
+        $objEspecieDocumentalBD = new EspecieDocumentalBD($this->getObjInfraIBanco());
+        return $objEspecieDocumentalBD->cadastrar($objEspecieDocumentalDTO);
+    } catch (Exception $e) {
+        throw new InfraException('Módulo do Tramita: Erro consultando mapeamento de documentos para envio.', $e);
+    }
+  }
+
+  protected function consultarConectado(EspecieDocumentalDTO $objEspecieDocumentalDTO)
+    {
+    try {
+        $objEspecieDocumentalBD = new EspecieDocumentalBD($this->getObjInfraIBanco());
+        return $objEspecieDocumentalBD->consultar($objEspecieDocumentalDTO);
+    } catch (Exception $e) {
+        throw new InfraException('Módulo do Tramita: Erro consultando mapeamento de documentos para envio.', $e);
+    }
+  }
+
+  protected function excluirConectado(EspecieDocumentalDTO $objEspecieDocumentalDTO)
+    {
+    try {
+        $objEspecieDocumentalBD = new EspecieDocumentalBD($this->getObjInfraIBanco());
+        return $objEspecieDocumentalBD->excluir($objEspecieDocumentalDTO);
+    } catch (Exception $e) {
+        throw new InfraException('Módulo do Tramita: Erro consultando mapeamento de documentos para envio.', $e);
+    }
+  }
+}

--- a/src/rn/PenRelTipoDocMapRecebidoRN.php
+++ b/src/rn/PenRelTipoDocMapRecebidoRN.php
@@ -128,6 +128,23 @@ class PenRelTipoDocMapRecebidoRN extends InfraRN
     }
   }
 
+      /**
+     * Lista mapeamentos de tipos de documentos para recebimento de processos pelo Barramento PEN
+     *
+     * @param PenRelTipoDocMapRecebidoDTO $parObjPenRelTipoDocMapRecebidoDTO
+     * @return array
+     */
+  protected function alterarConectado(PenRelTipoDocMapRecebidoDTO $parObjPenRelTipoDocMapRecebidoDTO)
+    {
+    try {
+        SessaoSEI::getInstance()->validarAuditarPermissao('pen_map_tipo_documento_recebimento_listar', __METHOD__, $parObjPenRelTipoDocMapRecebidoDTO);
+        $objPenRelTipoDocMapRecebidoBD = new PenRelTipoDocMapRecebidoBD($this->getObjInfraIBanco());
+        return $objPenRelTipoDocMapRecebidoBD->alterar($parObjPenRelTipoDocMapRecebidoDTO);
+    }catch(Exception $e){
+        throw new InfraException('Módulo do Tramita: Erro listando mapeamento de Tipos de Documento para recebimento.', $e);
+    }
+  }
+
     /**
      * Conta a lista de mapeamentos de tipos de documentos para envio de processos pelo Barramento PEN
      *

--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -650,7 +650,7 @@ class ProcessoEletronicoRN extends InfraRN
         'apenasAtivas' => true,
         'numeroDeIdentificacaoDaEstruturaRaizDaConsulta' => $numeroDeIdentificacaoDaEstruturaRaizDaConsulta,
         'sigla' => $siglaUnidade ?: null,
-        'nome' => !is_null($nomeUnidade) ? mb_convert_encoding($nomeUnidade, 'UTF-8') : (is_null($numeroDeIdentificacaoDaEstruturaRaizDaConsulta) && !is_null($nome) ? (is_numeric($nome) ? intval($nome) : mb_convert_encoding($nome, 'UTF-8')) : null),
+        'nome' => !is_null($nomeUnidade) ? mb_convert_encoding($nomeUnidade, 'UTF-8', 'ISO-8859-1') : (is_null($numeroDeIdentificacaoDaEstruturaRaizDaConsulta) && !is_null($nome) ? (is_numeric($nome) ? intval($nome) : mb_convert_encoding($nome, 'UTF-8', 'ISO-8859-1')) : null),
         'registroInicial' => !is_null($registrosPorPagina) && !is_null($offset) ? $offset : null,
         'quantidadeDeRegistros' => !is_null($registrosPorPagina) && !is_null($offset) ? $registrosPorPagina : null,
         'permiteRecebimento' => $parBolPermiteRecebimento ?: null,
@@ -663,7 +663,12 @@ class ProcessoEletronicoRN extends InfraRN
             }
         );
     
+        
+      if (is_numeric($nome)) {
+        $arrResultado = $this->consultarEstruturaSimples($idRepositorioEstrutura, $nome);
+      } else{
         $arrResultado = $this->consultarEstruturas($idRepositorioEstrutura, $parametros);
+      }
 
       if ($arrResultado->totalDeRegistros > 0) {
         foreach ($arrResultado->estruturas as $estrutura) {
@@ -745,7 +750,7 @@ class ProcessoEletronicoRN extends InfraRN
       if (isset($arrResultado)) {
         $count = count($arrResultado->especies);
         for ($i = 0; $i < $count; $i++) {
-            $codigo = $i + 1; 
+            $codigo = intval($arrResultado->especies[$i]->codigo);
             $arrEspecies[$codigo] = mb_convert_encoding($arrResultado->especies[$i]->nomeNoProdutor, 'ISO-8859-1', 'UTF-8');
         }
       }
@@ -2751,16 +2756,16 @@ class ProcessoEletronicoRN extends InfraRN
         $base64 = $arrResultado->getBody()->getContents();
         
       if($this->isJson($base64)){
-        $foo = json_decode($base64, false);
+        $objResposta = json_decode($base64, false);
       }else{
-        $foo = $base64;
+        $objResposta = $base64;
       }
         
-      if (is_array($foo)) {
-        return (object) $foo;
+      if (is_array($objResposta)) {
+        return (object) $objResposta;
       }
 
-        return $foo;
+        return $objResposta;
     } catch (RequestException $e) {
         $erroResposta = json_decode($e->getResponse()->getBody()->getContents());
         
@@ -2776,6 +2781,30 @@ class ProcessoEletronicoRN extends InfraRN
                 ]
             )
         );
+    }
+  }
+
+  public function consultarEstruturaSimples($idRepositorioEstrutura, $numeroDeIdentificacaoDaEstrutura)
+  {
+    $endpoint = "repositorios-de-estruturas/{$idRepositorioEstrutura}/estruturas-organizacionais/$numeroDeIdentificacaoDaEstrutura";
+    try {
+
+      $arrResultado = $this->get($endpoint);
+
+      $objResposta = new stdClass();
+      $objResposta->totalDeRegistros = 0;
+      
+      if (!is_null($arrResultado) && !empty($arrResultado)) {
+          $objResposta->estruturas = new stdClass();
+          $objResposta->estruturas->item = $arrResultado;
+          $objResposta->totalDeRegistros = 1;
+      }
+
+      return $objResposta;
+    } catch (Exception $e) {
+      $mensagem = "Falha na obtenção de unidades externas";
+      $detalhes = InfraString::formatarJavaScript($this->tratarFalhaWebService($e));
+      throw new InfraException($mensagem, $e, $detalhes);
     }
   }
   


### PR DESCRIPTION
- Ajustado o comportamento do campo de busca para aceitar corretamente palavras contendo caracteres UTF‑8, nos campos de “Unidades” no Tramita GOV.BR
- Corrigido o problema que impedia o envio quando um tipo de documento era adicionado ou substituído durante a tramitação.

Closes #810 #811