### PR TITLE
Documentos não assinados em processos abertos e sincronizados

### DIFF
--- a/src/pen_procedimento_expedir.php
+++ b/src/pen_procedimento_expedir.php
@@ -344,6 +344,10 @@ try {
           $objProcedimentoDTO = $objExpedirProcedimentoRN->consultarProcedimento($numIdProcedimento);
 
           $objProcessoEletronicoRN = new ProcessoEletronicoRN();
+          if ($objProcessoEletronicoRN->possuiDocumentoInternoNaoAssinado($numIdProcedimento)) {
+            throw new InfraException('Não é possível tramitar um processos com documentos gerados e não assinados');
+          }
+
           $tramitePendencia = $objProcessoEletronicoRN->consultarTramites(null, null, null, null, $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado());
           $enviarDireto = true;
           if (count($tramitePendencia) > 0) {

--- a/src/rn/PendenciasTramiteRN.php
+++ b/src/rn/PendenciasTramiteRN.php
@@ -105,7 +105,7 @@ class PendenciasTramiteRN extends InfraRN
             }
           }
 
-          $this->processarSolicitacoesSincronizacaoPendentes();
+          $this->processarSolicitacoesSincronizacaoPendentesConectado();
 
         } catch(ModuloIncompativelException $e) {
             // Sai loop de eventos para finalizar o script e subir uma nova versão atualizada
@@ -199,7 +199,7 @@ class PendenciasTramiteRN extends InfraRN
    */
   protected function processarSolicitacoesSincronizacaoPendentesConectado()
     {
-      $arrProcessosPendentes = $this->listarProcessosComSolicitacaoSincronizacaoPendente();
+      $arrProcessosPendentes = $this->listarProcessosComSolicitacaoSincronizacaoPendenteConectado();
 
     if (count($arrProcessosPendentes) === 0) {
         $this->gravarLogDebug('Nenhum processo com solicitação de sincronização pendente foi localizado.', 2);
@@ -253,11 +253,26 @@ class PendenciasTramiteRN extends InfraRN
           continue;
       }
 
-        $strMotivo = isset($objUltimoTramite->justificativaDaRecusa)
-            ? mb_convert_encoding($objUltimoTramite->justificativaDaRecusa, 'ISO-8859-1', 'UTF-8')
-            : 'Pedido de sincronização não concluído, pois foi cancelado ou recusado na plataforma de tramitação.';
+        if ($objUltimoTramite->situacaoAtual == ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_CANCELADO) {
+          $strNumeroProcesso = $dblIdProcedimento;
+          try {
+            $objExpedirProcedimentoRN = new ExpedirProcedimentoRN();
+            $objProcedimentoDTO = $objExpedirProcedimentoRN->consultarProcedimento($dblIdProcedimento);
+            if (!empty($objProcedimentoDTO) && !empty($objProcedimentoDTO->getStrProtocoloProcedimentoFormatado())) {
+              $strNumeroProcesso = $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado();
+            }
+          } catch (Exception $e) {
+            $this->gravarLogDebug(InfraException::inspecionar($e), 2);
+          }
 
-        $strMotivo .= '. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro.';
+          $strMotivo = "Tramitação externa do processo $strNumeroProcesso cancelada. O órgão de origem possui documentos internos gerados e não assinados, e por isso a sincronização não pode ser iniciada.";
+        } else {
+          $strMotivo = isset($objUltimoTramite->justificativaDaRecusa)
+              ? mb_convert_encoding($objUltimoTramite->justificativaDaRecusa, 'ISO-8859-1', 'UTF-8')
+              : 'Pedido de sincronização não concluído, pois foi cancelado ou recusado na plataforma de tramitação.';
+
+          $strMotivo .= '. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro.';
+        }
 
         $objProcessoEletronicoRN->validarProcessoRecusaCancelamento($dblIdProcedimento, $strMotivo);
 

--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -38,6 +38,7 @@ class ProcessoEletronicoRN extends InfraRN
 
   public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO = 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO';
   public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA = 'PEN_SINC_MULTIPLOS_ORGAOS_RECUSA';
+  public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_NAO_ASSINADO = 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_NAO_ASSINADO';
   public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO = 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO';
   
   public static $TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO = 'PEN_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO';
@@ -3322,6 +3323,50 @@ class ProcessoEletronicoRN extends InfraRN
       $objAtributoAndamentoRN->cadastrarRN1363($objAtributoAndamentoDTO);
     }
       
+  }
+
+  /**
+   * Verifica se o processo possui documento interno não assinado, ou seja, documento com status de editor interno e que não esteja cancelado, e que não possua assinatura cadastrada
+   *
+   * @param int $dblIdProcedimento
+   * @return bool
+   */
+  public function possuiDocumentoInternoNaoAssinado($dblIdProcedimento)
+  {
+    $objDocumentoDTO = new DocumentoDTO();
+    $objDocumentoDTO->setDblIdProcedimento($dblIdProcedimento);
+    $objDocumentoDTO->retDblIdDocumento();
+    $objDocumentoDTO->retStrStaDocumento();
+    $objDocumentoDTO->retStrStaEstadoProtocolo();
+
+    $objDocumentoRN = new DocumentoRN();
+    $arrObjDocumentoDTO = (array)$objDocumentoRN->listarRN0008($objDocumentoDTO);
+
+    if (empty($arrObjDocumentoDTO)) {
+      return false;
+    }
+
+    $objAssinaturaDTO = new AssinaturaDTO();
+    $objAssinaturaDTO->setDistinct(true);
+    $objAssinaturaDTO->retDblIdDocumento();
+
+    $objAssinaturaRN = new AssinaturaRN();
+    foreach ($arrObjDocumentoDTO as $objDocumentoDTO) {
+      if ($objDocumentoDTO->getStrStaDocumento() != DocumentoRN::$TD_EDITOR_INTERNO) {
+        continue;
+      }
+
+      if ($objDocumentoDTO->getStrStaEstadoProtocolo() == ProtocoloRN::$TE_DOCUMENTO_CANCELADO) {
+        continue;
+      }
+
+      $objAssinaturaDTO->setDblIdDocumento($objDocumentoDTO->getDblIdDocumento());
+      if ($objAssinaturaRN->contarRN1324($objAssinaturaDTO) == 0) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public function cadastrarAtividadePedidoSincronizacao(ProcedimentoDTO $objProcedimentoDTO, string $tarefa)

--- a/src/rn/SincronizacaoExpedirProcedimentoRN.php
+++ b/src/rn/SincronizacaoExpedirProcedimentoRN.php
@@ -38,6 +38,10 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
       //Busca metadados do processo registrado em trâmite anterior
       $objMetadadosProcessoTramiteAnterior = $this->consultarMetadadosPEN($dblIdProcedimento);
 
+      if ($this->objProcessoEletronicoRN->possuiDocumentoInternoNaoAssinado($dblIdProcedimento)) {
+        throw new InfraException('Módulo do Tramita: Sincronização não permitida para processos com documentos internos não assinados.');
+      }
+
       // Solicitar sincronização do documentos pendentes
       $numIdTramite = $this->objProcessoEletronicoRN->solicitarSincronizarTramite($objMetadadosProcessoTramiteAnterior->IDT);
       
@@ -78,6 +82,10 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
       //Apresentao da mensagens de validao na janela da barra de progresso
       if ($objInfraException->contemValidacoes() && $objExpedirProcedimentoDTO->getBolSinEnvioAutoMultiplosOrgaos() === false) {
         $objInfraException->lancarValidacoes();
+      }
+
+      if ($this->objProcessoEletronicoRN->possuiDocumentoInternoNaoAssinado($dblIdProcedimento)) {
+        throw new InfraException('Módulo do Tramita: Envio não permitido para processos com documentos internos não assinados.');
       }
 
       //Busca metadados do processo registrado em trâmite anterior
@@ -275,6 +283,10 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
       
       $this->objProcessoEletronicoRN->cadastrarAtividadePedidoSincronizacao($objProcedimentoDTO, ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO);
       $this->validarSincronizacaoProcessoSigiloso($dblIdProcedimento);
+      
+      if ($this->objProcessoEletronicoRN->possuiDocumentoInternoNaoAssinado($dblIdProcedimento)) {
+        throw new InfraException('Módulo do Tramita: Sincronização não permitida para processos com documentos internos não assinados.');
+      }
 
       //Busca metadados do processo registrado em trâmite anterior
       $objMetadadosProcessoTramiteAnterior = $objExpedirProcedimentoDTO->getObjMetadadosProcedimento();
@@ -396,6 +408,23 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
       $objProtocoloDTO = $objProtocoloRN->consultarRN0186($objProtocoloDTO);
       if (!empty($objProtocoloDTO)){
         $numIdUnidadeProcesso = ProcessoEletronicoRN::obterUnidadeParaRegistroDocumento($objProtocoloDTO->getDblIdProtocolo());
+
+        if ($objProcessoEletronicoRN->possuiDocumentoInternoNaoAssinado($objProtocoloDTO->getDblIdProtocolo())) {
+          $objProcedimentoDTO = $this->consultarProcedimento($objProtocoloDTO->getDblIdProtocolo());
+          
+          $objProcessoEletronicoRN->cancelarTramite($idTramite);
+          $objProcessoEletronicoRN->gravarAtividadeMultiplosOrgaos(
+            $objProcedimentoDTO,
+            $idTramite,
+            ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_NAO_ASSINADO,
+            $numIdUnidadeProcesso
+          );
+
+          $strMensagemErro = "Tramitação externa do processo $protocolo cancelada. Não é possível sincronizar processos com documentos internos gerados e não assinados.";
+          LogSEI::getInstance()->gravar($strMensagemErro, InfraLog::$ERRO);
+          $this->gravarLogDebug($strMensagemErro, 0, true);
+          return;
+        }
 
         $objExpedirProcedimentoDTO = new ExpedirProcedimentoDTO();
         $objExpedirProcedimentoDTO->setNumIdRepositorioOrigem($remetente->identificacaoDoRepositorioDeEstruturas);

--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -2698,6 +2698,7 @@ class PenAtualizarSeiRN extends PenAtualizadorRN
       $fnCadastrar('A sincronização foi interrompida, após o sistema de origem cancelar a tramitação - @PROTOCOLO_FORMATADO@. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro.', 'S', 'S', 'N', 'S', 'N', 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO');
       $fnCadastrar('A sincronização foi interrompida, após o sistema de destino rejeitar a tramitação. @MOTIVO_RECUSA@. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro', 'S', 'S', 'N', 'S', 'N', 'PEN_SINC_MULTIPLOS_ORGAOS_RECUSA');
       $fnCadastrar('A sincronização foi interrompida, após o sistema de origem cancelar a tramitação - @PROTOCOLO_FORMATADO@. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro.', 'S', 'S', 'N', 'S', 'N', 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO');
+      $fnCadastrar('Tramitação externa do processo @PROTOCOLO_FORMATADO@ cancelada. Não é possível sincronizar processos com documentos internos gerados e não assinados.', 'S', 'S', 'N', 'S', 'N', 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_NAO_ASSINADO');
 
       $fnCadastrar('Pedido de sincronização múltiplos órgãos recebida - @PROTOCOLO_FORMATADO@', 'S', 'S', 'N', 'N', 'N', 'PEN_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO');
       $fnCadastrar('Pedido envio de processo para múltiplos órgãos - @PROTOCOLO_FORMATADO@', 'S', 'S', 'N', 'S', 'N', 'PEN_PEDIDO_ENVIO_MULTIPLOS_ORGAOS');


### PR DESCRIPTION
Documentos não assinados em processos abertos e sincronizados afetam a tramitação futura por problemas com validação de hash.

Close #1091 