### PR TITLE
feat: correção para processo aberto e sincronizado

### DIFF
--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -617,13 +617,15 @@ class PENIntegracao extends SeiIntegracao
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO),
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO),
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA),
-        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO)
+        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO),
+        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM)
       ];
 
       $objAtividadeDTO = new AtividadeDTO();
       $objAtividadeDTO->setDblIdProtocolo($dblIdProcedimento);
       $objAtividadeDTO->setNumIdTarefa($arrTiProcessoEletronico, InfraDTO::$OPER_IN);
       $objAtividadeDTO->setOrdDthAbertura(InfraDTO::$TIPO_ORDENACAO_DESC);
+      $objAtividadeDTO->setOrdNumIdAtividade(InfraDTO::$TIPO_ORDENACAO_DESC);
       $objAtividadeDTO->setNumMaxRegistrosRetorno(1);
       $objAtividadeDTO->retNumIdAtividade();
       $objAtividadeDTO->retNumIdTarefa();
@@ -639,12 +641,13 @@ class PENIntegracao extends SeiIntegracao
         switch ($objAtividadeDTO->getNumIdTarefa()) {
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MANUAL_MULTIPLOS_ORGAOS):
+          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO):
             $title = "Pedido de sincronização realizado em " . $objAtividadeDTO->getDthAbertura();
             $arrayIcone = ['<img src="' . $this->getDiretorioImagens() . '/sincronizar_processo_pendente.png" title="'.$title.'" />'];
               break;
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_AUTO_ENVIO_MULTIPLOS_ORGAOS):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_ENVIO_MULTIPLOS_ORGAOS):
-          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO):
+          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_SUCESSO):
             $dataAbertura = $objAtividadeDTO->getDthConclusao() !== null ? $objAtividadeDTO->getDthConclusao() : $objAtividadeDTO->getDthAbertura();
             $title = "Sincronizado com sucesso em " . $dataAbertura;
             $arrayIcone = ['<img src="' . $this->getDiretorioImagens() . '/sincronizar_sucesso.png" title="'.$title.'" />'];
@@ -652,6 +655,7 @@ class PENIntegracao extends SeiIntegracao
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO):
+          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM):
             $title = "A sincronização não foi concluída em " . $objAtividadeDTO->getDthConclusao();
             $arrayIcone = ['<img src="' . $this->getDiretorioImagens() . '/sincronizar_falha.png" title="'.$title.'" />'];
               break;
@@ -788,13 +792,15 @@ class PENIntegracao extends SeiIntegracao
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO),
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO),
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA),
-        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO)
+        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO),
+        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM)
       ];
 
       $objAtividadeDTO = new AtividadeDTO();
       $objAtividadeDTO->setDblIdProtocolo($dblIdProcedimento);
       $objAtividadeDTO->setNumIdTarefa($arrTiProcessoEletronico, InfraDTO::$OPER_IN);
       $objAtividadeDTO->setOrdDthAbertura(InfraDTO::$TIPO_ORDENACAO_DESC);
+      $objAtividadeDTO->setOrdNumIdAtividade(InfraDTO::$TIPO_ORDENACAO_DESC);
       $objAtividadeDTO->setNumMaxRegistrosRetorno(1);
       $objAtividadeDTO->retNumIdAtividade();
       $objAtividadeDTO->retNumIdTarefa();
@@ -814,41 +820,19 @@ class PENIntegracao extends SeiIntegracao
         switch ($objAtividadeDTO->getNumIdTarefa()) {
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MANUAL_MULTIPLOS_ORGAOS):
-            try {
-              if ($objProcedimentoDTO->getStrStaEstadoProtocolo() == ProtocoloRN::$TE_PROCEDIMENTO_BLOQUEADO && is_null($objAtividadeDTO->getDthConclusao())) {
-                $objProcessoEletronicoDTO = new ProcessoEletronicoDTO();
-                $objProcessoEletronicoDTO->setDblIdProcedimento($dblIdProcedimento);
-                $objProcessoEletronicoRN = new ProcessoEletronicoRN();
-                $objTramiteDTO = $objProcessoEletronicoRN->consultarUltimoTramite($objProcessoEletronicoDTO);
-                $objTramitesAnteriores = $objProcessoEletronicoRN->consultarTramitesTodos(null, $objTramiteDTO->getStrNumeroRegistro());
-                $arrayRecusa = [
-                  ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_CANCELADO,
-                  ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_RECUSADO,
-                  ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_CANCELADO_AUTOMATICAMENTE,
-                  ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_CIENCIA_RECUSA
-                ];
-                if (isset($objTramitesAnteriores) && count($objTramitesAnteriores) > 0 && in_array($objTramitesAnteriores[count($objTramitesAnteriores)-1]->situacaoAtual, $arrayRecusa)) {
-                  $objProcessoEletronicoRN->desbloquearProcesso($dblIdProcedimento);
-                  $motivo = isset($objTramitesAnteriores[count($objTramitesAnteriores)-1]->justificativaDaRecusa) ? mb_convert_encoding($objTramitesAnteriores[count($objTramitesAnteriores)-1]->justificativaDaRecusa, 'iso-8859-1', 'utf-8') : 'Cancelado pelo usuário ou pelo administrador da plataforma';
-                  $motivo = str_replace('. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro.', '', $motivo); // Remove duplicidade de mensagem
-                  $objProcessoEletronicoRN->validarProcessoRecusaCancelamento($dblIdProcedimento, $motivo);
-                  echo "<script>window.location.reload();</script>";
-                }
-              }
-            } catch (Exception $e) {
-              // gravar log de erro caso necessário
-            }
+          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO):
             $arrObjArvoreAcaoItemAPI[] = $this->getObjArvoreAcaoSincronizadoPendente($dblIdProcedimento, $objAtividadeDTO->getDthAbertura());
               break;
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_AUTO_ENVIO_MULTIPLOS_ORGAOS):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_ENVIO_MULTIPLOS_ORGAOS):
-          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO):
+          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_SUCESSO):
             $dataAbertura = $objAtividadeDTO->getDthConclusao() !== null ? $objAtividadeDTO->getDthConclusao() : $objAtividadeDTO->getDthAbertura();
             $arrObjArvoreAcaoItemAPI[] = $this->getObjArvoreAcaoSincronizadoFinalizado($dblIdProcedimento, $dataAbertura);
               break;
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA):
           case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO):
+          case ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM):
             if ($objProcedimentoDTO->getStrStaEstadoProtocolo() == ProtocoloRN::$TE_PROCEDIMENTO_BLOQUEADO) {
               ProcessoEletronicoRN::desbloquearProcesso($dblIdProcedimento);
               echo "<script>window.location.reload();</script>";

--- a/src/pen_procedimento_sincronizar.php
+++ b/src/pen_procedimento_sincronizar.php
@@ -1,8 +1,14 @@
 <?php
-
 require_once DIR_SEI_WEB . '/SEI.php';
 
 session_start();
+
+$objPaginaSEI = null;
+$objSessaoSEI = null;
+$strParametros = '';
+$idProcedimento = '';
+
+$objInfraException = new InfraException();
 
 try {
     InfraDebug::getInstance()->setBolLigado(false);
@@ -16,7 +22,6 @@ try {
 
     $sincronizado = filter_var($_GET['sincronizado'], FILTER_SANITIZE_NUMBER_INT);
     $idProcedimento = filter_var($_GET['id_procedimento'], FILTER_SANITIZE_NUMBER_INT);
-    
 
     $strParametros = '';
   if (isset($_GET['arvore'])) {
@@ -27,7 +32,6 @@ try {
   if (isset($_GET['id_procedimento'])) {
       $strParametros .= '&id_procedimento=' . $_GET['id_procedimento'];
   }
-
   if (is_null($sincronizado) || $sincronizado == '') {
     $objSincronizacaoExpedirProcedimentoRN = new SincronizacaoExpedirProcedimentoRN();
     $objSincronizacaoExpedirProcedimentoRN->validarSincronizacaoProcessoSigiloso($idProcedimento);
@@ -51,8 +55,28 @@ try {
         $objTramiteDTO->getNumIdRepositorioDestino()
       );
       if (count($tramitePendencia) == 0) {
-        throw new InfraException('Ainda não e possível solicitar a sincronização para esse processo. É necessário realizar o envio do processo para outro órgão primeiro.');
+        $mensagem = "Ainda não e possível solicitar a sincronização para esse processo. É necessário realizar o envio do processo para outro órgão primeiro.";
+        $objInfraException->adicionarValidacao($mensagem);
+        throw new InfraException($mensagem);
       }
+
+      $objAtividadeDTO = new AtividadeDTO();
+      $objAtividadeDTO->setDistinct(true);
+      $objAtividadeDTO->retStrSiglaUnidade();
+      $objAtividadeDTO->setOrdStrSiglaUnidade(InfraDTO::$TIPO_ORDENACAO_ASC);
+      $objAtividadeDTO->setDblIdProtocolo($objProcedimentoDTO->getDblIdProcedimento());
+      $objAtividadeDTO->setDthConclusao(null);
+
+      $objAtividadeRN = new AtividadeRN();
+      $arrObjAtividadeDTO = $objAtividadeRN->listarRN0036($objAtividadeDTO);
+
+    if(isset($arrObjAtividadeDTO) && count($arrObjAtividadeDTO) > 1) {
+        $strSiglaUnidade = implode(', ', InfraArray::converterArrInfraDTO($arrObjAtividadeDTO, 'SiglaUnidade'));
+        $mensagem = "Atenção! Não é possível iniciar a sincronização de processos abertos em mais de uma unidade. "
+          . "Conclua o processo nas demais unidades antes de solicitar uma nova sincronia. (Processo aberto em: $strSiglaUnidade)";
+        $objInfraException->adicionarValidacao($mensagem);
+        throw new InfraException($mensagem);
+    }
 
       $objProcessoEletronicoRN->validarProcessoRecusaCancelamento($idProcedimento);
       $tramitePendencia = $objProcessoEletronicoRN->consultarTramites(null, $numNRE, null, null, null, null, ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_SOLICITACAO_PENDENCIA);
@@ -68,7 +92,6 @@ try {
         $objAtividadeDTO->setNumMaxRegistrosRetorno(1);
         $objAtividadeDTO->retTodos();
 
-        $objAtividadeRN = new AtividadeRN();
         $objAtividadeDTO = $objAtividadeRN->consultarRN0033($objAtividadeDTO);
 
         if($objAtividadeDTO) {
@@ -76,8 +99,8 @@ try {
           $objAtividadeRN->concluirRN0726([$objAtividadeDTO]);
         }
 
-        $objProcessoEletronicoRN->solicitarSincronizarTramite($objTramiteDTO->getNumIdTramite());
         $objProcessoEletronicoRN->bloquearProcesso($idProcedimento);
+        $objProcessoEletronicoRN->solicitarSincronizarTramite($objTramiteDTO->getNumIdTramite());
         // Atividade de pedido de sincronização para múltiplos órgãos manual - só adicionada após sucesso na solicitação de sincronização
         $objProcessoEletronicoRN->gravarAtividadeMultiplosOrgaos($objProcedimentoDTO, $objTramiteDTO->getNumIdTramite(), ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MANUAL_MULTIPLOS_ORGAOS);
       } else {
@@ -85,32 +108,64 @@ try {
       }
     }
 
-    $objPaginaSEI->setStrMensagem('Solicitação de sincronização realizada com sucesso.', InfraPagina::$TIPO_MSG_AVISO);
-    header('Location: '.$objSessaoSEI->assinarLink('controlador.php?acao=pen_procedimento_sincronizar&acao_origem='.$_GET['acao'].'&arvore='.$_GET['arvore'].'&sincronizado=1'.$objPaginaSEI->montarAncora($idProcedimento).$strParametros));
+    $objPaginaSEI->setStrMensagem('Solicitação de sincronização realizada com sucesso.', 5);
+    header('Location: '.$objSessaoSEI->assinarLink('controlador.php?acao=pen_procedimento_sincronizar&acao_origem='.$_GET['acao'].'&arvore='.$_GET['arvore'].'&sincronizado=1'.$strParametros.$objPaginaSEI->montarAncora($idProcedimento)));
     exit(0);
 
   } else {
-    $mensagem = $objPaginaSEI->getStrMensagens();
+    $mensagem = '';
+    if (isset($_GET['mensagem']) && $_GET['mensagem'] !== '') {
+      $mensagem = urldecode($_GET['mensagem']);
+    } else {
+      $mensagem = $objPaginaSEI->getStrMensagens();
+    }
     if ($mensagem !== '') {
       $objPaginaSEI->setStrMensagem('');
       ?>
-      <script type="text/javascript">
-        alert('<?php echo $mensagem ?>');
-        parent.parent.location.reload();
-      </script>
+      <div class="infraAreaAviso" style="background-color: #fff3cd; border: 1px solid #ffc107; padding: 10px; margin-bottom: 15px; border-radius: 4px;">
+          <img style="vertical-align: middle; margin-right: 8px; width: 25px;" src="<?php echo PENIntegracao::getDiretorioImagens() . '/icone-recusa.svg'; ?>" alt="Aviso" class="infraImg" />
+          <span style="color: #856404; font-weight: bold;">
+              <?php echo PaginaSEI::tratarHTML($mensagem); ?></strong>
+          </span>
+      </div>
       <?php
     }
-    // echo 'A sincronização do processo foi solicitada com sucesso.';
     exit(0);
   }
   
 } catch (InfraException $e) {
-  $objPaginaSEI->setStrMensagem($e->getMessage(), InfraPagina::$TIPO_MSG_AVISO);
-  header('Location: '.$objSessaoSEI->assinarLink('controlador.php?acao=pen_procedimento_sincronizar&acao_origem='.$_GET['acao'].'&arvore='.$_GET['arvore'].'&sincronizado=1'.$objPaginaSEI->montarAncora($idProcedimento).$strParametros));
+  $mensagem = 'Ocorreu um erro na sincronização do processo para múltiplos órgãos.';
+  if ($objInfraException->contemValidacoes()) {
+    $validacao = $objInfraException->getArrObjInfraValidacao();
+    $mensagem = $validacao[0]->getStrDescricao();
+  }
+  if ($objPaginaSEI !== null) {
+    $objPaginaSEI->setStrMensagem($mensagem, InfraPagina::$TIPO_MSG_AVISO);
+  }
+  $strAcao = isset($_GET['acao']) ? $_GET['acao'] : '';
+  $strArvore = isset($_GET['arvore']) ? $_GET['arvore'] : '';
+  $strAncora = ($objPaginaSEI !== null && $idProcedimento !== '') ? $objPaginaSEI->montarAncora($idProcedimento) : '';
+  $strParametrosErro = $strParametros . '&mensagem=' . urlencode($mensagem);
+  $strUrl = 'controlador.php?acao=pen_procedimento_sincronizar&acao_origem=' . $strAcao . '&arvore=' . $strArvore . '&sincronizado=1' . $strParametrosErro . $strAncora;
+  if ($objSessaoSEI !== null) {
+    $strUrl = $objSessaoSEI->assinarLink($strUrl);
+  }
+  header('Location: '.$strUrl);
   exit(0);
 } catch (Exception $e) {
-  $objPaginaSEI->setStrMensagem($e->getMessage(), InfraPagina::$TIPO_MSG_AVISO);
-  header('Location: '.$objSessaoSEI->assinarLink('controlador.php?acao=pen_procedimento_sincronizar&acao_origem='.$_GET['acao'].'&arvore='.$_GET['arvore'].'&sincronizado=1'.$objPaginaSEI->montarAncora($idProcedimento).$strParametros));
+  $mensagem = 'Ocorreu um erro na sincronização do processo para múltiplos órgãos.';
+  if ($objPaginaSEI !== null) {
+    $objPaginaSEI->setStrMensagem($mensagem, InfraPagina::$TIPO_MSG_AVISO);
+  }
+  $strAcao = isset($_GET['acao']) ? $_GET['acao'] : '';
+  $strArvore = isset($_GET['arvore']) ? $_GET['arvore'] : '';
+  $strAncora = ($objPaginaSEI !== null && $idProcedimento !== '') ? $objPaginaSEI->montarAncora($idProcedimento) : '';
+  $strParametrosErro = $strParametros . '&mensagem=' . urlencode($mensagem);
+  $strUrl = 'controlador.php?acao=pen_procedimento_sincronizar&acao_origem=' . $strAcao . '&arvore=' . $strArvore . '&sincronizado=1' . $strParametrosErro . $strAncora;
+  if ($objSessaoSEI !== null) {
+    $strUrl = $objSessaoSEI->assinarLink($strUrl);
+  }
+  header('Location: '.$strUrl);
   exit(0);
 }
 

--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -3029,6 +3029,30 @@ class ExpedirProcedimentoRN extends InfraRN
     }
   }
 
+  /**
+   * Validação das pré-condições necessárias para que um processo e seus documentos possam ser sincronizados para outra entidade
+   *
+   * @param InfraException $objInfraException Instância da classe de exceção para registro dos erros
+   * @param ProcedimentoDTO $objProcedimentoDTO Informações sobre o procedimento a ser sincronizado
+   * @param string $strAtributoValidacao Índice para o InfraException separar os processos
+   * @param bool $sinProcessoEmBloco Indica se o processo está sendo processado em bloco, para adequação das mensagens de validação
+   * @return void
+   * @throws InfraException Exceção lançada caso alguma pré-condição não seja atendida
+   */
+  public function validarPreCondicoesSincronizarProcedimento(
+      InfraException $objInfraException,
+      ProcedimentoDTO $objProcedimentoDTO,
+      $strAtributoValidacao = null,
+      $sinProcessoEmBloco = false
+  ) {
+    $this->validarDadosProcedimento($objInfraException, $objProcedimentoDTO, $strAtributoValidacao);
+    $this->validarDadosDocumentos($objInfraException, $objProcedimentoDTO->getArrObjDocumentoDTO(), $strAtributoValidacao);
+    $this->validarDocumentacaoExistende($objInfraException, $objProcedimentoDTO, $strAtributoValidacao, $sinProcessoEmBloco);
+    $this->validarNivelAcessoProcesso($objInfraException, $objProcedimentoDTO, $strAtributoValidacao);
+    $this->validarHipoteseLegalEnvio($objInfraException, $objProcedimentoDTO, $strAtributoValidacao);
+    $this->validarAssinaturas($objInfraException, $objProcedimentoDTO, $strAtributoValidacao, $sinProcessoEmBloco);
+  }
+
   public function verificarProcessosAbertoNaUnidade(InfraException $objInfraException, array $arrProtocolosOrigem)
     {
       $naoAbertoUnidadeAtual = false;
@@ -3084,17 +3108,18 @@ class ExpedirProcedimentoRN extends InfraRN
     {
     if ($objInfraException->contemValidacoes()) {
         $arrErros = [];
-        $message = "";
-      foreach ($objInfraException->getArrObjInfraValidacao() as $objInfraValidacao) {
+        $mensagem = "";
+        $listaValidacoes = $objInfraException->getArrObjInfraValidacao();
+      foreach ($listaValidacoes as $index => $objInfraValidacao) {
         $strAtributo = $objInfraValidacao->getStrAtributo();
         if (!array_key_exists($strAtributo, $arrErros)) {
             $arrErros[$strAtributo] = [];
         }
         $arrErros[$strAtributo][] = mb_convert_encoding($objInfraValidacao->getStrDescricao(), 'UTF-8', 'ISO-8859-1');
-        $message .= $objInfraValidacao->getStrDescricao() . "\n";
+        $mensagem .= ($index + 1) . ". " . mb_convert_encoding($objInfraValidacao->getStrDescricao(), 'UTF-8', 'ISO-8859-1') . "; ";
       }
 
-        return $message;
+        return $mensagem;
     }
 
       return null;

--- a/src/rn/PendenciasEnvioTramiteRN.php
+++ b/src/rn/PendenciasEnvioTramiteRN.php
@@ -188,6 +188,11 @@ class PendenciasEnvioTramiteRN extends PendenciasTramiteRN
       foreach ($arrAtividadeDTO as $objAtividadeDTO) {
         $objExpedirProcedimentoRN = new ExpedirProcedimentoRN();
         $objProcedimentoDTO = $objExpedirProcedimentoRN->consultarProcedimento($objAtividadeDTO->getDblIdProtocolo());
+
+        if ($this->possuiTramiteEmAndamento($objProcedimentoDTO)) {
+          continue;
+        }
+
         $pendendciasAutomaticas[] = $objProcedimentoDTO;
         
         $objAtividadeRN->concluirRN0726([$objAtividadeDTO]);
@@ -196,6 +201,43 @@ class PendenciasEnvioTramiteRN extends PendenciasTramiteRN
       }
     }
 
+  }
+
+  /**
+   * Verifica se o protocolo possui algum trâmite ainda em andamento.
+   *
+   * @param ProcedimentoDTO $objProcedimentoDTO
+   * @return bool
+   */
+  private function possuiTramiteEmAndamento(ProcedimentoDTO $objProcedimentoDTO)
+  {
+    $objProcessoEletronicoRN = new ProcessoEletronicoRN();
+    $arrTramites = (array)$objProcessoEletronicoRN->consultarTramitesTodos(
+      null,
+      null,
+      null,
+      null,
+      $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado()
+    );
+
+    $arrSituacoesConcluidas = [
+      ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_RECIBO_RECEBIDO_REMETENTE,
+      ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_CANCELADO,
+      ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_CIENCIA_RECUSA,
+      ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_CANCELADO_AUTOMATICAMENTE
+    ];
+
+    foreach ($arrTramites as $objTramite) {
+      if (!isset($objTramite->situacaoAtual) || !in_array($objTramite->situacaoAtual, $arrSituacoesConcluidas)) {
+        $this->gravarLogDebug(
+          'Envio automático ignorado para o protocolo ' . $objProcedimentoDTO->getStrProtocoloProcedimentoFormatado() . ': existe trâmite em andamento.',
+          2
+        );
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/src/rn/PendenciasTramiteRN.php
+++ b/src/rn/PendenciasTramiteRN.php
@@ -165,6 +165,7 @@ class PendenciasTramiteRN extends InfraRN
 
       $objAtividadeDTO = new AtividadeDTO();
       $objAtividadeDTO->setNumIdTarefa($arrIdTarefaSincronizacaoPendente, InfraDTO::$OPER_IN);
+      $objAtividadeDTO->setDthConclusao(null);
       $objAtividadeDTO->setOrdDthAbertura(InfraDTO::$TIPO_ORDENACAO_ASC);
       $objAtividadeDTO->retNumIdAtividade();
       $objAtividadeDTO->retNumIdTarefa();
@@ -556,6 +557,10 @@ class PendenciasTramiteRN extends InfraRN
 
         case ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_RECUSADO:
             $client->addTaskBackground("receberTramitesRecusados", $numIDT, null, $numIDT);
+            break;
+
+        case ProcessoEletronicoRN::$STA_SITUACAO_TRAMITE_SOLICITACAO_PENDENCIA:
+            $client->addTaskBackground("enviarSincronizacaoTramite", $numIDT, null, $numIDT);
             break;
 
         default:

--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -37,9 +37,11 @@ class ProcessoEletronicoRN extends InfraRN
   public static $TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS = 'PEN_PEDIDO_SINC_MULTIPLOS_ORGAOS';
 
   public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO = 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO';
+  public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM = 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM';
   public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA = 'PEN_SINC_MULTIPLOS_ORGAOS_RECUSA';
   public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_NAO_ASSINADO = 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_NAO_ASSINADO';
   public static $TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO = 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO';
+  public static $TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_SUCESSO = 'PEN_PEDIDO_SINC_MULTIPLOS_ORGAOS_SUCESSO';
   
   public static $TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO = 'PEN_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO';
   public static $TI_PROCESSO_ELETRONICO_PEDIDO_ENVIO_MULTIPLOS_ORGAOS = 'PEN_PEDIDO_ENVIO_MULTIPLOS_ORGAOS';
@@ -3191,7 +3193,8 @@ class ProcessoEletronicoRN extends InfraRN
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO),
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO),
         ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA),
-        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO)
+        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_AUTO),
+        ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM)
       ];
 
       $objAtividadeDTO = new AtividadeDTO();
@@ -3295,8 +3298,15 @@ class ProcessoEletronicoRN extends InfraRN
     $objAtributoAndamentoRN->cadastrarRN1363($objAtributoAndamentoDTO);
 
     if (!empty($motivoRecusa)) {
+      $eRecusaSincronizacao = $penTarefa == ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA;
+      $temObsRecusa = strpos($motivoRecusa, '. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro.') !== false;
+      if ($eRecusaSincronizacao && $temObsRecusa) {
+        $motivoRecusa = str_replace('. OBS: A recusa é uma das três formas de conclusão de trâmite. Portanto, não é um erro.', '', $motivoRecusa);
+      }
+      $atributoNome = $penTarefa == ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM
+          ? 'MOTIVO_CANCELAMENTO' : 'MOTIVO_RECUSA';
       $objAtributoAndamentoDTO = new AtributoAndamentoDTO();
-      $objAtributoAndamentoDTO->setStrNome('MOTIVO_RECUSA');
+      $objAtributoAndamentoDTO->setStrNome($atributoNome);
       $objAtributoAndamentoDTO->setStrValor($motivoRecusa);
       $objAtributoAndamentoDTO->setStrIdOrigem($objProcedimentoDTO->getDblIdProcedimento());
       $objAtributoAndamentoDTO->setNumIdAtividade($objAtividadeDTO->getNumIdAtividade());

--- a/src/rn/SincronizacaoExpedirProcedimentoRN.php
+++ b/src/rn/SincronizacaoExpedirProcedimentoRN.php
@@ -281,7 +281,6 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
       $objProcedimentoDTO->setArrObjDocumentoDTO($this->listarDocumentos($dblIdProcedimento));
       $objProcedimentoDTO->setArrObjParticipanteDTO($this->listarInteressados($dblIdProcedimento));
       
-      $this->objProcessoEletronicoRN->cadastrarAtividadePedidoSincronizacao($objProcedimentoDTO, ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO);
       $this->validarSincronizacaoProcessoSigiloso($dblIdProcedimento);
       
       if ($this->objProcessoEletronicoRN->possuiDocumentoInternoNaoAssinado($dblIdProcedimento)) {
@@ -407,16 +406,52 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
       $objProtocoloRN = new ProtocoloRN();
       $objProtocoloDTO = $objProtocoloRN->consultarRN0186($objProtocoloDTO);
       if (!empty($objProtocoloDTO)){
+        $objProcedimentoDTO = $this->consultarProcedimento($objProtocoloDTO->getDblIdProtocolo());
         $numIdUnidadeProcesso = ProcessoEletronicoRN::obterUnidadeParaRegistroDocumento($objProtocoloDTO->getDblIdProtocolo());
 
+        $objProcessoEletronicoRN->cadastrarAtividadePedidoSincronizacao($objProcedimentoDTO, ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO);
+
+        $dblIdProcedimento = $objProtocoloDTO->getDblIdProtocolo();
+        $objInfraException = new InfraException();
+        $objExpedirProcedimentosRN = new ExpedirProcedimentoRN();
+        $objProcedimentoDTO->setArrObjDocumentoDTO($objExpedirProcedimentosRN->listarDocumentos($dblIdProcedimento));
+        $objProcedimentoDTO->setArrObjParticipanteDTO($objExpedirProcedimentosRN->listarInteressados($dblIdProcedimento));
+        $objExpedirProcedimentosRN->validarPreCondicoesSincronizarProcedimento($objInfraException, $objProcedimentoDTO, $protocolo);
+
+        if ($objInfraException->contemValidacoes()) {
+          $strValidacoes = rtrim($this->trazerTextoSeContemValidacoes($objInfraException));
+          $strMensagemErro = "";
+
+          if ($strValidacoes !== '') {
+            $strMensagemErro .= mb_convert_encoding($strValidacoes, 'ISO-8859-1', 'UTF-8');
+          }
+
+          $cabecalhoMsg = "Tramitação externa do processo $protocolo cancelada. ";
+          LogSEI::getInstance()->gravar($cabecalhoMsg . $strMensagemErro, InfraLog::$ERRO);
+          $this->gravarLogDebug($cabecalhoMsg . $strMensagemErro, 0, true);
+
+          $this->concluirAtividadePendenteSincronizacao($objProcedimentoDTO->getDblIdProcedimento());
+
+          $objProcessoEletronicoRN->gravarAtividadeMultiplosOrgaos(
+            $objProcedimentoDTO,
+            $idTramite,
+            ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM,
+            $numIdUnidadeProcesso,
+            $strMensagemErro
+          );
+
+          $objProcessoEletronicoRN->cancelarTramite($idTramite);
+          return;
+        }
+
         if ($objProcessoEletronicoRN->possuiDocumentoInternoNaoAssinado($objProtocoloDTO->getDblIdProtocolo())) {
-          $objProcedimentoDTO = $this->consultarProcedimento($objProtocoloDTO->getDblIdProtocolo());
-          
+          $this->concluirAtividadePendenteSincronizacao($objProcedimentoDTO->getDblIdProcedimento());
+
           $objProcessoEletronicoRN->cancelarTramite($idTramite);
           $objProcessoEletronicoRN->gravarAtividadeMultiplosOrgaos(
             $objProcedimentoDTO,
             $idTramite,
-            ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_NAO_ASSINADO,
+            ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM,
             $numIdUnidadeProcesso
           );
 
@@ -455,6 +490,8 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
         $numIDT = $objProtocoloDTO->getDblIdProtocolo();
         $numTempoTotalEnvio = round(microtime(true) - $numTempoInicialEnvio, 2);
         $this->gravarLogDebug("Finalizado o envio de protocolo com IDProcedimento $numIDT(Tempo total: {$numTempoTotalEnvio}s)", 0, true);
+        $objProcessoEletronicoRN->cadastrarAtividadePedidoSincronizacao($objProcedimentoDTO, ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_SUCESSO);
+        $this->concluirAtividadePendenteSincronizacao($objProcedimentoDTO->getDblIdProcedimento());
       } else {
         $objProcessoEletronicoRN->cancelarTramite($idTramite);
         $this->gravarLogDebug("Sincronismo do $protocolo: Protocolo não encontrado. Tramite $idTramite cancelado", 0, true);
@@ -462,6 +499,23 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
     } catch (\Exception $e) {
       if (!empty($objProtocoloDTO) && $objProtocoloDTO->getDblIdProtocolo()) {
         $this->reabrirProcessoSeBloqueado($objProtocoloDTO->getDblIdProtocolo());
+
+        try {
+          $objProcedimentoDTO = $this->consultarProcedimento($objProtocoloDTO->getDblIdProtocolo());
+          $numIdUnidadeProcesso = ProcessoEletronicoRN::obterUnidadeParaRegistroDocumento($objProtocoloDTO->getDblIdProtocolo());
+
+          $this->concluirAtividadePendenteSincronizacao($objProcedimentoDTO->getDblIdProcedimento());
+
+          $objProcessoEletronicoRN->gravarAtividadeMultiplosOrgaos(
+            $objProcedimentoDTO,
+            $idTramite,
+            ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_SINC_MULTIPLOS_ORGAOS_RECUSA,
+            $numIdUnidadeProcesso,
+            'Erro no processamento da sincronização: ' . $e->getMessage()
+          );
+        } catch (\Exception $ex) {
+          $this->gravarLogDebug("Erro ao gravar atividade de falha na sincronizacao de tramite: $ex", 2, true);
+        }
       }
 
       //Nao recusa tramite caso o processo atual nao possa ser desbloqueado, evitando que o processo fique aberto em dois sistemas ao mesmo tempo
@@ -475,6 +529,41 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
 
       $this->gravarLogDebug("Erro processando envio de sincronizacao de tramite: $e", 0, true);
       throw new InfraException('M\363dulo do Tramita: Falha de comunica\347\343o com o servi\347os de integra\347\343o. Por favor, tente novamente mais tarde.', $e);
+    }
+  }
+
+  /**
+   * Conclui a atividade pendente de sincronização para evitar que ela permaneça
+   * como status mais recente quando o trâmite é cancelado por erro.
+   *
+   * @param mixed $dblIdProcedimento
+   * @return void
+   */
+  private function concluirAtividadePendenteSincronizacao($dblIdProcedimento)
+  {
+    if (empty($dblIdProcedimento)) {
+      return;
+    }
+
+    try {
+      $idTarefa = ProcessoEletronicoRN::obterIdTarefaModulo(ProcessoEletronicoRN::$TI_PROCESSO_ELETRONICO_PEDIDO_SINC_MULTIPLOS_ORGAOS_RECEBIDO);
+
+      $objAtividadeDTO = new AtividadeDTO();
+      $objAtividadeDTO->setDblIdProtocolo($dblIdProcedimento);
+      $objAtividadeDTO->setDthConclusao(null);
+      $objAtividadeDTO->setDistinct(true);
+      $objAtividadeDTO->setNumIdTarefa($idTarefa);
+      $objAtividadeDTO->setNumMaxRegistrosRetorno(1);
+      $objAtividadeDTO->retTodos();
+
+      $objAtividadeRN = new AtividadeRN();
+      $objAtividadeDTO = $objAtividadeRN->consultarRN0033($objAtividadeDTO);
+
+      if ($objAtividadeDTO) {
+        $objAtividadeRN->concluirRN0726([$objAtividadeDTO]);
+      }
+    } catch (\Exception $e) {
+      $this->gravarLogDebug("Erro ao concluir atividade pendente de sincronizacao do processo $dblIdProcedimento: $e", 2, true);
     }
   }
 

--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -2712,6 +2712,8 @@ class PenAtualizarSeiRN extends PenAtualizadorRN
       $fnCadastrar('Pedido envio automático de processo para múltiplos órgãos - @PROTOCOLO_FORMATADO@', 'S', 'S', 'N', 'N', 'N', 'PEN_PEDIDO_AUTO_ENVIO_MULTIPLOS_ORGAOS');
       $fnCadastrar('Processo de envio automático realizado para múltiplos órgãos - @PROTOCOLO_FORMATADO@', 'S', 'S', 'N', 'S', 'N', 'PEN_PROCESSO_AUTO_ENVIO_MULTIPLOS_ORGAOS');
       $fnCadastrar('Envio de processo múltiplos órgãos para o remetente - @PROTOCOLO_FORMATADO@', 'S', 'S', 'N', 'S', 'N', 'PEN_ENVIO_MULTIPLOS_ORGAOS_REMETENTE');
+      $fnCadastrar('A sincronização foi interrompida, após o sistema de destino cancelar a tramitação. @MOTIVO_CANCELAMENTO@', 'S', 'S', 'N', 'S', 'N', 'PEN_SINC_MULTIPLOS_ORGAOS_CANCELADO_ORIGEM');
+      $fnCadastrar('Pedido de sincronização múltiplos órgãos realizada com sucesso - @PROTOCOLO_FORMATADO@', 'S', 'S', 'N', 'S', 'N', 'PEN_PEDIDO_SINC_MULTIPLOS_ORGAOS_SUCESSO');
 
       $fnCadastrar('A ordem dos documentos foi alterada automaticamente para a ordem original devido a sincronização de processo para múltiplos órgãos', 'S', 'S', 'N', 'S', 'N', 'PEN_REORDENACAO_AUTOMATICA_PROCESSO');
 


### PR DESCRIPTION
Closes #1018 #1056 #1113 #1158 #1159 

- Corrigir processo com documento sigiloso;
- Registrar mensagem de recusa para processo com documento não assinado;
- Remover OBS de tarefas triplicado;
- Mensagem de processo aberto em mais de uma unidade no pedido de sincronizar manual;
- Validar antes do envio atomatico se existe tramite em andamento;