### PR TITLE
Atualizacao testes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,15 +289,15 @@ tramitar-pendencias:
   	done
 
 tramitar-pendencias-simples: tramitar-pendencias-simples-org1 tramitar-pendencias-simples-org2
-	@$(CMD_COMPOSE_FUNC) exec org1-http php /opt/sei/scripts/mod-pen/MonitoramentoRecebimentoTarefasPEN.php;
+	@$(CMD_COMPOSE_FUNC) exec -e XDEBUG_MODE=off org1-http php /opt/sei/scripts/mod-pen/MonitoramentoRecebimentoTarefasPEN.php;
 
 tramitar-pendencias-simples-org1:
-	@$(CMD_COMPOSE_FUNC) exec org1-http php /opt/sei/scripts/mod-pen/MonitoramentoEnvioTarefasPEN.php; \
-	$(CMD_COMPOSE_FUNC) exec org1-http php /opt/sei/scripts/mod-pen/MonitoramentoRecebimentoTarefasPEN.php;
+	@$(CMD_COMPOSE_FUNC) exec -e XDEBUG_MODE=off org1-http php /opt/sei/scripts/mod-pen/MonitoramentoEnvioTarefasPEN.php; \
+	$(CMD_COMPOSE_FUNC) exec -e XDEBUG_MODE=off org1-http php /opt/sei/scripts/mod-pen/MonitoramentoRecebimentoTarefasPEN.php;
 
 tramitar-pendencias-simples-org2:
-	@$(CMD_COMPOSE_FUNC) exec org2-http php /opt/sei/scripts/mod-pen/MonitoramentoEnvioTarefasPEN.php; \
-	$(CMD_COMPOSE_FUNC) exec org2-http php /opt/sei/scripts/mod-pen/MonitoramentoRecebimentoTarefasPEN.php;
+	@$(CMD_COMPOSE_FUNC) exec -e XDEBUG_MODE=off org2-http php /opt/sei/scripts/mod-pen/MonitoramentoEnvioTarefasPEN.php; \
+	$(CMD_COMPOSE_FUNC) exec -e XDEBUG_MODE=off org2-http php /opt/sei/scripts/mod-pen/MonitoramentoRecebimentoTarefasPEN.php;
 
 tramitar-pendencias-silent:
 	@echo 'Executando monitoramento de pendências do Org1 e Org2'

--- a/tests_sei5/funcional/docker-compose.yml
+++ b/tests_sei5/funcional/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     image: ${SOLR_IMAGE}:${ENVIRONMENT_VERSION}
     ports:
       - "8983:8983"
+    environment:
+      - SOLR_HEAP=256m 
   selenium:
     image: selenium/standalone-chrome-debug
     links:
@@ -49,6 +51,10 @@ services:
       - org2-database
       - selenium
     volumes:
+      #Permite o container de teste se comunicar com o Docker da máquina que subiu o ambiente, para que ele possa mandar comandos aos outros containers (org1-http-1, org2-http-1)
+      - /var/run/docker.sock:/var/run/docker.sock
+      #Para que o comando docker esteja disponível dentro do container de teste
+      - /usr/bin/docker:/usr/bin/docker
       - ${SEI_PATH}/sei:/opt/sei
       - ${SEI_PATH}/sip:/opt/sip
       - ${SEI_PATH}/infra:/opt/infra
@@ -66,6 +72,9 @@ services:
       - ./assets/config/ConfiguracaoSEI.php:/tests/sei/src/sei/config/ConfiguracaoSEI.php:ro
       - ../../src:/tests/sei/src/sei/web/modulos/pen
       - ./assets/config:/tests/sei/src/sei/config/mod-pen
+      # ASSINATURA ELETRONICA
+      - ../../../mod-sei-assinatura-eletronica/src:/tests/sei/src/sei/web/modulos/assinatura-eletronica
+      - ../../../mod-sei-assinatura-eletronica/src/config:/tests/sei/src/sei/config/mod-assinatura-eletronica
     environment:
       - XDEBUG_CONFIG=client_host=host.docker.internal client_port=9003 start_with_request=0
       - XDEBUG_SESSION=default
@@ -156,6 +165,13 @@ services:
       - ./assets/config/composer.json:/opt/sei/web/modulos/pen/composer.json
       - ./composer.phar:/opt/sei/web/modulos/pen/composer.phar
       - ../../vendor:/opt/sei/web/modulos/pen/vendor
+      # ASSINATURA ELETRONICA
+      - ../../../mod-sei-assinatura-eletronica/composer.phar:/opt/sei/web/modulos/assinatura-eletronica/composer.phar
+      - ../../../mod-sei-assinatura-eletronica/composer.json:/opt/sei/web/modulos/assinatura-eletronica/composer.json
+      - ../../../mod-sei-assinatura-eletronica/src:/opt/sei/web/modulos/assinatura-eletronica
+      - ../../../mod-sei-assinatura-eletronica/src/config:/opt/sei/config/mod-assinatura-eletronica
+      - ../../../mod-sei-assinatura-eletronica/src/scripts:/opt/sei/scripts/mod-assinatura-eletronica
+      - ../../../mod-sei-assinatura-eletronica/src/scripts:/opt/sip/scripts/mod-assinatura-eletronica      
     environment:
       - LANG=pt_BR.ISO-8859-1
       - HOST_URL=http://${ORG1_HOSTNAME}:${ORG1_PORT}
@@ -217,6 +233,13 @@ services:
       - ./assets/config/composer.json:/opt/sei/web/modulos/pen/composer.json
       - ./composer.phar:/opt/sei/web/modulos/pen/composer.phar
       - ../../vendor:/opt/sei/web/modulos/pen/vendor
+      # ASSINATURA ELETRONICA
+      - ../../../mod-sei-assinatura-eletronica/composer.phar:/opt/sei/web/modulos/assinatura-eletronica/composer.phar
+      - ../../../mod-sei-assinatura-eletronica/composer.json:/opt/sei/web/modulos/assinatura-eletronica/composer.json
+      - ../../../mod-sei-assinatura-eletronica/src:/opt/sei/web/modulos/assinatura-eletronica
+      - ../../../mod-sei-assinatura-eletronica/src/config:/opt/sei/config/mod-assinatura-eletronica
+      - ../../../mod-sei-assinatura-eletronica/src/scripts:/opt/sei/scripts/mod-assinatura-eletronica
+      - ../../../mod-sei-assinatura-eletronica/src/scripts:/opt/sip/scripts/mod-assinatura-eletronica      
     environment:
       - LANG=pt_BR.ISO-8859-1
       - HOST_URL=http://${ORG2_HOSTNAME}:${ORG2_PORT}

--- a/tests_sei5/funcional/phpunit.xml
+++ b/tests_sei5/funcional/phpunit.xml
@@ -28,6 +28,9 @@
     <const name="PEN_SCRIPT_MONITORAMENTO_ORG1" value=" " />
     <const name="PEN_SCRIPT_MONITORAMENTO_ORG2" value=" " />
     <const name="ENVIO_PARCIAL" value="true" />
+
+    <!-- Flag para desativar agendamento, de modo que o comando de tramitação aconteça sob demanda, e não pelo prazo configurado no SEI -->
+    <const name="DESATIVAR_AGENDAMENTO" value="true" />
  
     <!-- Chaves de configuração dos diferentes ambientes envolvidos no teste do Barramento de
     Serviços do PEN -->

--- a/tests_sei5/funcional/src/paginas/PaginaCadastrarProcessoEmBloco.php
+++ b/tests_sei5/funcional/src/paginas/PaginaCadastrarProcessoEmBloco.php
@@ -165,12 +165,13 @@ class PaginaCadastrarProcessoEmBloco extends PaginaTeste
       string $unidadeDestinoHierarquia,
       bool $urgente = false,
       ?callable $callbackEnvio = null,
-      int $timeout = PEN_WAIT_TIMEOUT
+      int $timeout = PEN_WAIT_TIMEOUT,
+      bool $executarTramitarPendencias = true
   ): void {
     // 1) Executa os selects e o botão Enviar
     $this->selectRepositorio($repositorio);
     $this->selectUnidade($unidadeDestino, 'origem', $unidadeDestinoHierarquia);
-    $this->btnEnviar();
+    $this->btnEnviar();    
   
     // 2) Captura (e fecha) o alerta inicial, mas só lança exceção
     //    se veio texto e não foi passado callback personalizado
@@ -214,6 +215,12 @@ class PaginaCadastrarProcessoEmBloco extends PaginaTeste
         // Sempre restaura o frame principal e a visualização
         $this->frame(null);
         // $this->frame('ifrVisualizacao');
+    }
+
+    // executa pendências APÓS confirmação de envio
+    if (DESATIVAR_AGENDAMENTO == 'true' && $executarTramitarPendencias) {
+      // Equivalente ao: make tramitar-pendencias-simples, após clicar no botão enviar (para órgão externo)
+      $this->test->executarTramitarPendenciasSimples();
     }
   
     // 5) Pausa curta para dar tempo de estabilizar a UI
@@ -298,5 +305,5 @@ class PaginaCadastrarProcessoEmBloco extends PaginaTeste
   public function btnEnviar(): void
     {
       $this->elByXPath("//button[@type='button' and @value='Enviar']")->click();
-  }
+    }
 }

--- a/tests_sei5/funcional/src/paginas/PaginaControleProcesso.php
+++ b/tests_sei5/funcional/src/paginas/PaginaControleProcesso.php
@@ -54,8 +54,7 @@ class PaginaControleProcesso extends PaginaTeste
    */
   public function abrirProcesso(string $strProtocolo): void
   {
-      sleep(1);
-      $this->elByLinkText($strProtocolo)->click();
+      $this->elByPartialLinkText($strProtocolo)->click();
   }
 
   protected function listarProcessos($processosGerados, $processosRecebidos)

--- a/tests_sei5/funcional/src/paginas/PaginaTramitarProcesso.php
+++ b/tests_sei5/funcional/src/paginas/PaginaTramitarProcesso.php
@@ -18,6 +18,16 @@ class PaginaTramitarProcesso extends PaginaTeste
      */
   public function repositorio(string $siglaRepositorio = null): ?string
     {
+      // Aguarda o select de repositório estar disponível
+      $this->waitUntil(function() {
+          try {
+              $this->elById('selRepositorioEstruturas');
+              return true;
+          } catch (\Exception $e) {
+              return false;
+          }
+      }, PEN_WAIT_TIMEOUT);
+
       $select = new WebDriverSelect(
           $this->elById('selRepositorioEstruturas')
       );

--- a/tests_sei5/funcional/src/paginas/PaginaTramiteMapeamentoOrgaoExterno.php
+++ b/tests_sei5/funcional/src/paginas/PaginaTramiteMapeamentoOrgaoExterno.php
@@ -83,11 +83,19 @@ class PaginaTramiteMapeamentoOrgaoExterno extends PaginaTeste
     /**
      * Trata o alerta padrão e confirma via ENTER se houver texto.
      */
-  private function handleAlert(): void
+    private function handleAlert(): void
     {
-      $msg = parent::alertTextAndClose();
-    if ($msg !== null) {
-        $this->driver->getKeyboard()->pressKey(WebDriverKeys::ENTER);
+      try {
+          $this->test->waitUntil(function() {
+              try {
+                  $this->driver->switchTo()->alert()->accept();
+                  return true;
+              } catch (\Exception $e) {
+                  return false;
+              }
+          }, PEN_WAIT_TIMEOUT);
+      } catch (\Exception $e) {
+          // sem alert, segue em frente
+      }
     }
-  }
 }

--- a/tests_sei5/funcional/tests/CancelamentoTramiteIndividualTest.php
+++ b/tests_sei5/funcional/tests/CancelamentoTramiteIndividualTest.php
@@ -64,6 +64,9 @@ class CancelamentoTramiteIndividualTest extends FixtureCenarioBaseTestCase
             self::$destinatario['REP_ESTRUTURAS'],
             self::$destinatario['NOME_UNIDADE'],
             self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+            false,
+            null,
+            PEN_WAIT_TIMEOUT,
             false
         );
 
@@ -77,7 +80,6 @@ class CancelamentoTramiteIndividualTest extends FixtureCenarioBaseTestCase
         $this->abrirProcesso(self::$protocoloTestePrincipal);
 
         $this->paginaProcesso->cancelarTramitacaoExterna();
-        sleep(5);
         $mensagemAlerta = $this->paginaTramitar->alertTextAndClose(true);
         $mensagemEsperada = mb_convert_encoding("O trâmite externo do processo foi cancelado com sucesso!", 'UTF-8', 'ISO-8859-1');
         $this->assertStringContainsString($mensagemEsperada, $mensagemAlerta);
@@ -98,6 +100,9 @@ class CancelamentoTramiteIndividualTest extends FixtureCenarioBaseTestCase
             self::$destinatario['REP_ESTRUTURAS'],
             self::$destinatario['NOME_UNIDADE'],
             self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+            false,
+            null,
+            PEN_WAIT_TIMEOUT,
             false
         );
 
@@ -106,11 +111,9 @@ class CancelamentoTramiteIndividualTest extends FixtureCenarioBaseTestCase
         $this->acessarSistema(self::$destinatario['URL'], self::$destinatario['SIGLA_UNIDADE'], self::$destinatario['LOGIN'], self::$destinatario['SENHA']);
         $this->paginaAgendamentos->navegarAgendamento();
         $this->paginaAgendamentos->executarAgendamento('PENAgendamentoRN :: processarTarefasRecebimentoPEN');
-        sleep(5);
 
         $this->paginaBase->navegarParaControleProcesso();
         $this->waitUntil(function() use ($strProtocoloTeste) {
-            sleep(5);
             try {
                 $this->paginaBase->refresh();
                 $this->paginaControleProcesso->abrirProcesso($strProtocoloTeste);
@@ -121,8 +124,7 @@ class CancelamentoTramiteIndividualTest extends FixtureCenarioBaseTestCase
 
         }, PEN_WAIT_TIMEOUT);
 
-        // Esperar o processo tramitar
-        // sleep(20);
+        
         $this->sairSistema();
         
 
@@ -131,7 +133,6 @@ class CancelamentoTramiteIndividualTest extends FixtureCenarioBaseTestCase
         $this->abrirProcesso(self::$protocoloTestePrincipal);
 
         $this->paginaProcesso->cancelarTramitacaoExterna();
-        sleep(5);
         $mensagemAlerta = $this->paginaTramitar->alertTextAndClose(true);
         $mensagemEsperada = mb_convert_encoding('O sistema destinatário já iniciou o recebimento desse processo, portanto não é possível realizar o cancelamento', 'UTF-8', 'ISO-8859-1');
         $this->assertStringContainsString($mensagemEsperada, $mensagemAlerta);

--- a/tests_sei5/funcional/tests/CenarioBaseTestCase.php
+++ b/tests_sei5/funcional/tests/CenarioBaseTestCase.php
@@ -224,6 +224,16 @@ class CenarioBaseTestCase extends TestCase
         $strTarja = stream_get_contents($result[0]["TEXTO"]);
         $bancoOrgaoA->execute("update tarja_assinatura set texto=? where sta_tarja_assinatura=? and sin_ativo=?", array($strTarja, "V", "S"));
     }
+
+    if (DESATIVAR_AGENDAMENTO == 'true') {
+        $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);    
+        $bancoOrgaoA->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasEnvioPEN'));
+        $bancoOrgaoA->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasRecebimentoPEN'));
+
+        $bancoOrgaoB = new DatabaseUtils(CONTEXTO_ORGAO_B);
+        $bancoOrgaoB->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasEnvioPEN'));
+        $bancoOrgaoB->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasRecebimentoPEN'));
+      }
   }
 
   public static function tearDownAfterClass(): void
@@ -231,6 +241,20 @@ class CenarioBaseTestCase extends TestCase
     if (self::$driver) {
         self::$driver->quit();
     }
+
+    if (DESATIVAR_AGENDAMENTO == 'true') {
+        
+            parent::tearDownAfterClass();
+            $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);    
+            $bancoOrgaoA->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('S', 'PENAgendamentoRN::processarTarefasEnvioPEN'));
+            $bancoOrgaoA->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('S', 'PENAgendamentoRN::processarTarefasRecebimentoPEN'));
+
+            $bancoOrgaoB = new DatabaseUtils(CONTEXTO_ORGAO_B);
+            $bancoOrgaoB->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('S', 'PENAgendamentoRN::processarTarefasEnvioPEN'));
+            $bancoOrgaoB->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('S', 'PENAgendamentoRN::processarTarefasRecebimentoPEN'));
+
+        }
+
   }
 
   public function setUp(): void
@@ -245,15 +269,6 @@ class CenarioBaseTestCase extends TestCase
   protected function url(string $url): void
     {
       self::$driver->get($url);
-  }
-
-    /**
-     * Espera até a condição ser verdadeira
-     */
-  protected function waitUntil(callable $condition, int $timeout = PEN_WAIT_TIMEOUT): void
-    {
-      $wait = new WebDriverWait(self::$driver, $timeout);
-      $wait->until($condition);
   }
 
   protected function definirContextoTeste($nomeContexto)
@@ -331,8 +346,8 @@ class CenarioBaseTestCase extends TestCase
         $this->paginaControleProcesso->abrirProcesso($protocolo);
     } catch (\Exception $e) {
         $this->paginaBase->pesquisar($protocolo);
-        sleep(2);
-        $this->paginaBase->elByXPath('(//a[@id="lnkInfraMenuSistema"])[2]')->click();
+        sleep(1);
+        $this->paginaBase->elByXPath('//a[@id="lnkInfraMenuSistema"]')->click(); //ícone de 3 risquinhos horizontais que abre/fecha o menu
     }
   }
 
@@ -352,7 +367,7 @@ class CenarioBaseTestCase extends TestCase
       return $protocolo;
   }
 
-  protected function tramitarProcessoExternamente($protocolo, $repositorio, $unidadeDestino, $unidadeDestinoHierarquia, $urgente = false, $callbackEnvio = null, $timeout = PEN_WAIT_TIMEOUT)
+  protected function tramitarProcessoExternamente($protocolo, $repositorio, $unidadeDestino, $unidadeDestinoHierarquia, $urgente = false, $callbackEnvio = null, $timeout = PEN_WAIT_TIMEOUT, $executarTramitarPendencias = true)
     {
       $this->paginaProcesso->navegarParaTramitarProcesso();
     
@@ -399,14 +414,27 @@ class CenarioBaseTestCase extends TestCase
       }
     }
 
-      sleep(1);
+    // executa pendências APÓS confirmação de envio
+    if (DESATIVAR_AGENDAMENTO == 'true' && $executarTramitarPendencias) {
+      // Equivalente ao: make tramitar-pendencias-simples, após clicar no botão enviar (para órgão externo)
+      $this->executarTramitarPendenciasSimples();
+    }
   }
 
-  protected function tramitarProcessoExternamenteComValidacaoRemetente($protocolo, $repositorio, $unidadeDestino, $unidadeDestinoHierarquia, $urgente = false, $callbackEnvio = null, $timeout = PEN_WAIT_TIMEOUT)
+  protected function tramitarProcessoExternamenteComValidacaoRemetente($protocolo, $repositorio, $unidadeDestino, $unidadeDestinoHierarquia, $urgente = false, $callbackEnvio = null, $timeout = PEN_WAIT_TIMEOUT, $executarTramitarPendencias = true)
     {
-      $this->tramitarProcessoExternamente($protocolo, $repositorio, $unidadeDestino, $unidadeDestinoHierarquia, $urgente, $callbackEnvio, $timeout);
+      $this->tramitarProcessoExternamente(
+        $protocolo, 
+        $repositorio, 
+        $unidadeDestino, 
+        $unidadeDestinoHierarquia, 
+        $urgente, 
+        $callbackEnvio, 
+        $timeout, 
+        $executarTramitarPendencias
+      );
       $this->waitUntil(function() {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -423,7 +451,7 @@ class CenarioBaseTestCase extends TestCase
       $this->validarRecibosTramite($mensagemRecibo, true, true);
       $this->validarHistoricoTramite($unidadeDestino, true, true);
       $this->validarProcessosTramitados($protocolo, true);
-  }
+  } 
 
   protected function tramitarProcessoInternamente($unidadeDestino, $manterAbertoNaUnidadeAtual = false)
     {
@@ -436,7 +464,6 @@ class CenarioBaseTestCase extends TestCase
         $this->paginaTramitar->manterAbertoNaUnidadeAtual();
     }
       $this->paginaTramitar->tramitarInterno();
-
       sleep(1);
   }
 
@@ -466,15 +493,13 @@ class CenarioBaseTestCase extends TestCase
     if ($protocolo) {
         $this->paginaControleProcesso->abrirProcesso($protocolo['PROTOCOLO']);
     }
-
-      sleep(1);
   }
 
   protected function validarRecibosTramite($mensagem, $verificarReciboEnvio, $verificarReciboConclusao)
     {
       $mensagem = mb_convert_encoding($mensagem, 'UTF-8', 'ISO-8859-1');
       $this->waitUntil(function() use ($mensagem, $verificarReciboEnvio, $verificarReciboConclusao) {
-          sleep(5);
+          sleep(2);
           $this->paginaProcesso->refresh();
           $this->paginaProcesso->navegarParaConsultarRecibos();
         if($this->paginaReciboTramite->contemTramite($mensagem, $verificarReciboEnvio, $verificarReciboConclusao)) {
@@ -504,9 +529,7 @@ class CenarioBaseTestCase extends TestCase
     if ($verificarProcessoRejeitado) {
 
         $this->waitUntil(function() use ($unidadeDestino, $motivoRecusa) {
-            sleep(2);
             $this->paginaProcesso->refresh();
-            sleep(2);
             $this->paginaProcesso->navegarParaConsultarAndamentos();
             $andamento = $this->paginaConsultarAndamentos->contemTramiteProcessoRejeitado($unidadeDestino, $motivoRecusa);
           if ($andamento){
@@ -522,7 +545,6 @@ class CenarioBaseTestCase extends TestCase
 
   protected function validarDadosProcesso($descricao, $restricao, $observacoes, $listaInteressados, $hipoteseLegal = null)
     {
-      sleep(2);
       $this->paginaProcesso->navegarParaEditarProcesso();
       $this->assertEquals(mb_convert_encoding($descricao, 'UTF-8', 'ISO-8859-1'), $this->paginaEditarProcesso->descricao());
       $this->assertEquals($restricao, $this->paginaEditarProcesso->restricao());
@@ -544,19 +566,16 @@ class CenarioBaseTestCase extends TestCase
 
   protected function validarDocumentoCancelado($nomeDocArvore)
     {
-      sleep(2);
       $this->assertTrue($this->paginaProcesso->ehDocumentoCancelado($nomeDocArvore));
   }
 
   protected function validarDocumentoMovido($nomeDocArvore)
     {
-      sleep(2);
       $this->assertTrue($this->paginaProcesso->ehDocumentoMovido($nomeDocArvore));
   }
 
   protected function validarDadosDocumento($nomeDocArvore, $dadosDocumento, $destinatario, $unidadeSecundaria = false, $hipoteseLegal = null)
     {
-      sleep(2);
 
       // Verifica se documento possui marcação de documento anexado
       $bolPossuiDocumentoReferenciado = !is_null($dadosDocumento['ORDEM_DOCUMENTO_REFERENCIADO']);
@@ -595,7 +614,7 @@ class CenarioBaseTestCase extends TestCase
       $this->paginaBase->navegarParaControleProcesso();
       $txtPesquisaMenu = $this->paginaBase->elById("txtInfraPesquisarMenu");
       if (!$txtPesquisaMenu->isDisplayed()) {
-          $this->paginaBase->elByXPath('(//a[@id="lnkInfraMenuSistema"])[2]')->click();
+          $this->paginaBase->elByXPath('//a[@id="lnkInfraMenuSistema"]')->click();//ícone de 3 risquinhos horizontais que abre/fecha o menu
       }
       $this->paginaBase->navegarPara("Processos em Tramitação Externa");
       $this->assertEquals($deveExistir, $this->paginaProcessosTramitadosExternamente->contemProcesso($protocolo));
@@ -607,6 +626,27 @@ class CenarioBaseTestCase extends TestCase
       $this->assertTrue($this->paginaControleProcesso->contemProcesso(self::$protocoloTeste));
       $this->assertTrue($this->paginaControleProcesso->contemAlertaProcessoRecusado(self::$protocoloTeste));
   }
+
+  /**
+   * Espera até a condição ser verdadeira
+   */
+  public function waitUntil(callable $condition, int $timeout = PEN_WAIT_TIMEOUT): void
+  {
+    $wait = new WebDriverWait(self::$driver, $timeout);
+    $wait->until($condition);
+  }
+
+  public function executarTramitarPendenciasSimples(): void
+    {
+        $scriptEnvio       = 'php /opt/sei/scripts/mod-pen/MonitoramentoEnvioTarefasPEN.php';
+        $scriptRecebimento = 'php /opt/sei/scripts/mod-pen/MonitoramentoRecebimentoTarefasPEN.php';
+
+        shell_exec("docker exec -e XDEBUG_MODE=off funcional-org1-http-1 {$scriptEnvio}");
+        shell_exec("docker exec -e XDEBUG_MODE=off funcional-org1-http-1 {$scriptRecebimento}");
+        shell_exec("docker exec -e XDEBUG_MODE=off funcional-org2-http-1 {$scriptEnvio}");
+        shell_exec("docker exec -e XDEBUG_MODE=off funcional-org2-http-1 {$scriptRecebimento}");
+        shell_exec("docker exec -e XDEBUG_MODE=off funcional-org1-http-1 {$scriptRecebimento}");
+    }
 
   public function gerarDadosProcessoTeste($contextoProducao)
     {
@@ -690,7 +730,6 @@ class CenarioBaseTestCase extends TestCase
 
       // 11 - Abrir protocolo na tela de controle de processos
       $this->waitUntil(function() use ($strProtocoloTeste) {
-          sleep(5);
           $this->abrirProcessoControleProcesso($strProtocoloTeste);
           return true;
       }, PEN_WAIT_TIMEOUT);
@@ -726,7 +765,7 @@ class CenarioBaseTestCase extends TestCase
 
       // Abrir protocolo na tela de controle de processos pelo texto da descrição
       $this->waitUntil(function() use ($strDescricao, &$strProtocoloTeste) {
-        sleep(5);
+        sleep(2);
         try {
             $this->paginaBase->refresh();
             $strProtocoloTeste = $this->abrirProcessoPelaDescricao($strDescricao);    

--- a/tests_sei5/funcional/tests/FixtureCenarioBaseTestCase.php
+++ b/tests_sei5/funcional/tests/FixtureCenarioBaseTestCase.php
@@ -183,7 +183,7 @@ class FixtureCenarioBaseTestCase extends CenarioBaseTestCase
       return $objProtocoloDTO[0];
   }
 
-  protected function realizarTramiteExternoFixture(&$processoTeste, $documentosTeste, $remetente, $destinatario, $validarTramite)
+  protected function realizarTramiteExternoFixture(&$processoTeste, $documentosTeste, $remetente, $destinatario, $validarTramite, $executarTramitarPendencias = true)
     {
       $orgaosDiferentes = $remetente['URL'] != $destinatario['URL'];
 
@@ -216,12 +216,21 @@ class FixtureCenarioBaseTestCase extends CenarioBaseTestCase
       $this->abrirProcesso($strProtocoloTeste);
         
       // 5 - Trâmitar Externamento processo para órgão/unidade destinatária
-      $this->tramitarProcessoExternamente($strProtocoloTeste, $destinatario['REP_ESTRUTURAS'], $destinatario['NOME_UNIDADE'], $destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+      $this->tramitarProcessoExternamente(
+        $strProtocoloTeste, 
+        $destinatario['REP_ESTRUTURAS'], 
+        $destinatario['NOME_UNIDADE'], 
+        $destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false, 
+        null, 
+        PEN_WAIT_TIMEOUT, 
+        $executarTramitarPendencias
+      );
 
     if ($validarTramite) {
         // 6 - Verificar se situação atual do processo está como bloqueado
         $this->waitUntil(function() use (&$orgaosDiferentes) {
-            sleep(5);
+            sleep(1);
             $this->paginaProcesso->refresh();
           try {
               $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -247,14 +256,14 @@ class FixtureCenarioBaseTestCase extends CenarioBaseTestCase
     }
   }
     
-  public function realizarTramiteExternoComValidacaoNoRemetenteFixture(&$processoTeste, $documentosTeste, $remetente, $destinatario)
+  public function realizarTramiteExternoComValidacaoNoRemetenteFixture(&$processoTeste, $documentosTeste, $remetente, $destinatario, $executarTramitarPendencias = true)
     {
-      $this->realizarTramiteExternoFixture($processoTeste, $documentosTeste, $remetente, $destinatario, true);
+      $this->realizarTramiteExternoFixture($processoTeste, $documentosTeste, $remetente, $destinatario, true, $executarTramitarPendencias);
   }
 
-  public function realizarTramiteExternoSemValidacaoNoRemetenteFixture(&$processoTeste, $documentosTeste, $remetente, $destinatario)
+  public function realizarTramiteExternoSemValidacaoNoRemetenteFixture(&$processoTeste, $documentosTeste, $remetente, $destinatario, $executarTramitarPendencias = true)
     {
-      $this->realizarTramiteExternoFixture($processoTeste, $documentosTeste, $remetente, $destinatario, false);
+      $this->realizarTramiteExternoFixture($processoTeste, $documentosTeste, $remetente, $destinatario, false, $executarTramitarPendencias);
   }
 
   protected function buscarIdSerieDoDocumento($tipoDocumento)

--- a/tests_sei5/funcional/tests/MapeamentoDeUnidadesComLimitacaoDeRepositoriosTest.php
+++ b/tests_sei5/funcional/tests/MapeamentoDeUnidadesComLimitacaoDeRepositoriosTest.php
@@ -47,7 +47,7 @@ class MapeamentoDeUnidadesComLimitacaoDeRepositoriosTest extends FixtureCenarioB
     );
     $this->paginaMapUnidades->navegarPenMapeamentoUnidades();
     $this->paginaMapUnidades->pesquisarUnidade(self::$remetente['SIGLA_UNIDADE']);
-    sleep(2);
+    sleep(1);
 
     $this->paginaMapUnidades->selecionarEditar();
     $this->paginaMapUnidades->limparRestricoes();
@@ -56,7 +56,7 @@ class MapeamentoDeUnidadesComLimitacaoDeRepositoriosTest extends FixtureCenarioB
     $this->paginaMapUnidades->selecionarUnidade(self::$remetente['NOME_UNIDADE']);
 
     $this->paginaMapUnidades->salvar();
-    sleep(2);
+    sleep(1);
     $mensagem = $this->paginaMapUnidades->buscarMensagemAlerta();
     $this->assertStringContainsString(
       'Mapeamento de Unidade gravado com sucesso.',

--- a/tests_sei5/funcional/tests/MapeamentoDeUnidadesComUnidadeNaoVinculadaARepositorioSelecionadoTest.php
+++ b/tests_sei5/funcional/tests/MapeamentoDeUnidadesComUnidadeNaoVinculadaARepositorioSelecionadoTest.php
@@ -45,14 +45,14 @@ class MapeamentoDeUnidadesComUnidadeNaoVinculadaARepositorioSelecionadoTest exte
     );
     $this->paginaMapUnidades->navegarPenMapeamentoUnidades();
     $this->paginaMapUnidades->pesquisarUnidade(self::$remetente['SIGLA_UNIDADE']);
-    sleep(2);
+    sleep(1);
 
     $this->paginaMapUnidades->selecionarEditar();
     $this->paginaMapUnidades->limparRestricoes();
 
     $this->paginaMapUnidades->selecionarRepoEstruturas(self::$remetente['REP_ESTRUTURAS']);
     $this->paginaMapUnidades->selecionarUnidadeComAlert(1234567);
-    sleep(2);
+    sleep(1);
     $mensagem = $this->paginaBase->alertTextAndClose();
     $mensagemEsperada = mb_convert_encoding(
       "A unidade pesquisada não está vinculada à estrutura organizacional selecionada: ".self::$remetente['REP_ESTRUTURAS'].". "

--- a/tests_sei5/funcional/tests/MapeamentoDeUnidadesTest.php
+++ b/tests_sei5/funcional/tests/MapeamentoDeUnidadesTest.php
@@ -138,7 +138,7 @@ class MapeamentoDeUnidadesTest extends FixtureCenarioBaseTestCase
     $this->paginaMapUnidades->selecionarUnidadePenCadastro(CONTEXTO_ORGAO_B_SIGLA_ESTRUTURA);
     $this->paginaMapUnidades->salvar();
 
-    sleep(2);
+    sleep(1);
 
     $mensagem = $this->paginaMapUnidades->buscarMensagemAlerta();
     $this->assertStringContainsString(
@@ -167,7 +167,7 @@ class MapeamentoDeUnidadesTest extends FixtureCenarioBaseTestCase
 
     $this->paginaMapUnidades->excluirMapeamentosExistentes();
 
-    sleep(2);
+    sleep(1);
     
     $this->assertFalse($this->paginaMapUnidades->existeTabela());
     

--- a/tests_sei5/funcional/tests/MapeamentoTipoProcessoDesativarReativarTest.php
+++ b/tests_sei5/funcional/tests/MapeamentoTipoProcessoDesativarReativarTest.php
@@ -96,17 +96,24 @@ class MapeamentoTipoProcessoDesativarReativarTest extends FixtureCenarioBaseTest
       $this->paginaTramiteMapeamentoOrgaoExterno->selectEstado("Inativo");
       $this->paginaTramiteMapeamentoOrgaoExterno->reativarMapeamento();
 
-      $page = $this->paginaTramiteMapeamentoOrgaoExterno;
+
+
+
+
+
+
       $mensagemValidacao = mb_convert_encoding('Relacionamento entre Unidades foi reativado com sucesso.', 'UTF-8', 'ISO-8859-1');
-      $this->waitUntil(
-          fn() => mb_strpos(
-                $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta(),
-                $mensagemValidacao
-            ) !== false,
-          PEN_WAIT_TIMEOUT
-      );
-        
+
       // ao final garante de fato que a mensagem existe
+      $this->waitUntil(function() use ($mensagemValidacao) {
+          try {
+              $mensagem = $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta();
+              return !empty($mensagem) && mb_strpos($mensagem, $mensagemValidacao) !== false;
+          } catch (\Exception $e) {
+              return false;
+          }
+      }, PEN_WAIT_TIMEOUT);
+
       $this->assertStringContainsString(
           $mensagemValidacao,
           $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta()
@@ -131,21 +138,24 @@ class MapeamentoTipoProcessoDesativarReativarTest extends FixtureCenarioBaseTest
       );
       $this->paginaTramiteMapeamentoOrgaoExterno->navegarRelacionamentoEntreOrgaos();
 
-      $this->paginaTramiteMapeamentoOrgaoExterno->selectEstado("Ativo");
+      $this->paginaTramiteMapeamentoOrgaoExterno->selectEstado("Ativo");      
       $this->paginaTramiteMapeamentoOrgaoExterno->desativarMapeamentoCheckbox();
-      $page = $this->paginaTramiteMapeamentoOrgaoExterno;
+      
       $mensagemValidacao = mb_convert_encoding('Relacionamento entre Unidades foi desativado com sucesso.', 'UTF-8', 'ISO-8859-1');
-      $this->waitUntil(
-          fn() => mb_strpos(
-                $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta(),
-                $mensagemValidacao
-            ) !== false,
-          PEN_WAIT_TIMEOUT
-      );
-      $this->assertStringContainsString(
-          $mensagemValidacao,
-          $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta()
-      );
+
+      $this->waitUntil(function() use ($mensagemValidacao) {
+          try {
+              $mensagem = $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta();
+              return !empty($mensagem) && mb_strpos($mensagem, $mensagemValidacao) !== false;
+          } catch (\Exception $e) {
+              return false;
+          }
+      }, PEN_WAIT_TIMEOUT);
+
+        $this->assertStringContainsString(
+            $mensagemValidacao,
+            $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta()
+        );
         
       $this->sairSistema();
   }
@@ -168,17 +178,18 @@ class MapeamentoTipoProcessoDesativarReativarTest extends FixtureCenarioBaseTest
       $this->paginaTramiteMapeamentoOrgaoExterno->navegarRelacionamentoEntreOrgaos();
 
       $this->paginaTramiteMapeamentoOrgaoExterno->selectEstado("Inativo");
-      $this->paginaTramiteMapeamentoOrgaoExterno->reativarMapeamentoCheckbox();
-      $page = $this->paginaTramiteMapeamentoOrgaoExterno;
+      $this->paginaTramiteMapeamentoOrgaoExterno->reativarMapeamentoCheckbox();     
       $mensagemValidacao = mb_convert_encoding('Relacionamento entre Unidades foi reativado com sucesso.', 'UTF-8', 'ISO-8859-1');
-      $this->waitUntil(
-          fn() => mb_strpos(
-                $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta(),
-                $mensagemValidacao
-            ) !== false,
-          PEN_WAIT_TIMEOUT
-      );
       // ao final garante de fato que a mensagem existe
+      $this->waitUntil(function() use ($mensagemValidacao) {
+          try {
+              $mensagem = $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta();
+              return !empty($mensagem) && mb_strpos($mensagem, $mensagemValidacao) !== false;
+          } catch (\Exception $e) {
+              return false;
+          }
+      }, PEN_WAIT_TIMEOUT);
+
       $this->assertStringContainsString(
           $mensagemValidacao,
           $this->paginaTramiteMapeamentoOrgaoExterno->buscarMensagemAlerta()

--- a/tests_sei5/funcional/tests/MapeamentoTipoProcessoExcluirTest.php
+++ b/tests_sei5/funcional/tests/MapeamentoTipoProcessoExcluirTest.php
@@ -59,10 +59,21 @@ class MapeamentoTipoProcessoExcluirTest extends FixtureCenarioBaseTestCase
       );
 
       $this->paginaTramiteMapeamentoOrgaoExterno->navegarRelacionamentoEntreOrgaos();
-      sleep(5);
+
+
+
       $this->paginaCadastroOrgaoExterno->selecionarExcluirMapOrgao(self::$penOrgaoExternoId);
-      sleep(1);
-      $mensagem = $this->paginaCadastroOrgaoExterno->buscarMensagemAlerta();
+
+      $mensagem = null;
+      $this->waitUntil(function() use (&$mensagem) {
+          try {
+              $mensagem = $this->paginaCadastroOrgaoExterno->buscarMensagemAlerta();
+              return !empty($mensagem);
+          } catch (\Exception $e) {
+              return false;
+          }
+      }, PEN_WAIT_TIMEOUT);
+
       $this->assertStringContainsString(
           mb_convert_encoding('Relacionamento entre unidades foi excluído com sucesso.', 'UTF-8', 'ISO-8859-1'),
           $mensagem

--- a/tests_sei5/funcional/tests/MapeamentoTipoProcessoRelacionamentoOrgaosCadastroTest.php
+++ b/tests_sei5/funcional/tests/MapeamentoTipoProcessoRelacionamentoOrgaosCadastroTest.php
@@ -46,13 +46,21 @@ class MapeamentoTipoProcessoRelacionamentoOrgaosCadastroTest extends FixtureCena
           self::$remetente['NOME_UNIDADE']
       );
       $this->paginaCadastroOrgaoExterno->salvar();
-      // sleep(10);
+
+      $mensagem = null;
+      $this->waitUntil(function() use (&$mensagem) {
+          try {
+              $mensagem = $this->paginaCadastroOrgaoExterno->buscarMensagemAlerta();
+              return !empty($mensagem);
+          } catch (\Exception $e) {
+              return false;
+          }
+      }, PEN_WAIT_TIMEOUT);
+
       $orgaoOrigem = $this->paginaCadastroOrgaoExterno->buscarOrgao(self::$destinatario['NOME_UNIDADE']);
       $orgaoDestino = $this->paginaCadastroOrgaoExterno->buscarOrgao(self::$remetente['NOME_UNIDADE']);
-      // var_dump($orgaoDestino,$orgaoDestino);
       $this->assertNotNull($orgaoOrigem);
-      $this->assertNotNull($orgaoDestino);
-      sleep(1);
+      $this->assertNotNull($orgaoDestino);      
       $mensagem = $this->paginaCadastroOrgaoExterno->buscarMensagemAlerta();
       $this->assertStringContainsString(
           mb_convert_encoding('Relacionamento entre Unidades cadastrado com sucesso.', 'UTF-8', 'ISO-8859-1'),

--- a/tests_sei5/funcional/tests/ProcessoBlocoDeTramiteTravasDeTramitacaoTest.php
+++ b/tests_sei5/funcional/tests/ProcessoBlocoDeTramiteTravasDeTramitacaoTest.php
@@ -53,8 +53,14 @@ class ProcessoBlocoDeTramiteTravasDeTramitacaoTest extends FixtureCenarioBaseTes
       $this->paginaCadastrarProcessoEmBloco->bntTramitarBloco();
     try {
       $this->paginaCadastrarProcessoEmBloco->tramitarProcessoExternamente(
-          self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+          self::$destinatario['REP_ESTRUTURAS'], 
+          self::$destinatario['NOME_UNIDADE'],
+          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
+      );
     } catch (Exception $ex) {
       $this->assertStringContainsString(
           utf8_encode('Não é possível tramitar um processo aberto em mais de uma unidade.'),

--- a/tests_sei5/funcional/tests/RecebimentoRecusaJustificativaGrandeTest.php
+++ b/tests_sei5/funcional/tests/RecebimentoRecusaJustificativaGrandeTest.php
@@ -47,7 +47,13 @@ class RecebimentoRecusaJustificativaGrandeTest extends FixtureCenarioBaseTestCas
       self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
       self::$documentoTeste = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
 
-      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
+      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(
+        self::$processoTeste, 
+        self::$documentoTeste, 
+        self::$remetente, 
+        self::$destinatario,
+        false
+      );
       self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
 
       $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);
@@ -58,8 +64,7 @@ class RecebimentoRecusaJustificativaGrandeTest extends FixtureCenarioBaseTestCas
     }else{
         $id_tramite=$id_tramite[0]["ID_TRAMITE"];
     }
-
-      sleep(5);
+    
       $this->recusarTramite($id_tramite);        
   }
 
@@ -74,6 +79,10 @@ class RecebimentoRecusaJustificativaGrandeTest extends FixtureCenarioBaseTestCas
      */
   public function test_verificar_destino_processo_para_devolucao()
     {
+      if (DESATIVAR_AGENDAMENTO == 'true') {
+        $this->executarTramitarPendenciasSimples();
+      }
+
       // Configuração do dados para teste do cenário
       self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
 
@@ -83,7 +92,7 @@ class RecebimentoRecusaJustificativaGrandeTest extends FixtureCenarioBaseTestCas
 
       $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
       $this->validarRecibosTramite(sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade), true, false);
-      $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, false, true, sprintf("An exception occurred while executing 'INSERT INTO juntadas (numeracao_sequencial, movimento, ativo, vinculada, criado_em, atualizado_em, id, uuid, documentos_juntado_id, volumes_id, atividades_id, tarefas_id, comunicacoes_id, origem_dados_id, criado_por, atualizado_por) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, 'DOCUMENTO RECEBIDO VIA INTEGRA\u00c7\u00c3O COM O BARRAMENTO', 1, 0, '2021-12-02 14:21:48', '2021-12-02 14:21:48', 1317074776, '06ba31e8-75ad-4111-82d ..."));
+      $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, false, true, sprintf("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing ..."));
 
       //Verifica se os í­cones de alerta de recusa foram adicionados e se o processo continua aberto na unidade
       $this->paginaBase->navegarParaControleProcessoIcone();
@@ -94,7 +103,7 @@ class RecebimentoRecusaJustificativaGrandeTest extends FixtureCenarioBaseTestCas
     
   private function recusarTramite($id_tramite)
     {
-      $justificativa = "An exception occurred while executing 'INSERT INTO juntadas (numeracao_sequencial, movimento, ativo, vinculada, criado_em, atualizado_em, id, uuid, documentos_juntado_id, volumes_id, atividades_id, tarefas_id, comunicacoes_id, origem_dados_id, criado_por, atualizado_por) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, 'DOCUMENTO RECEBIDO VIA INTEGRA\u00c7\u00c3O COM O BARRAMENTO', 1, 0, '2021-12-02 14:21:48', '2021-12-02 14:21:48', 1317074776, '06ba31e8-75ad-4111-82dc-6f451f51825e', 1333864526, null, null, null, null, 3534979787, null, null]: ORA-00001: restrição exclusiva (SAPIENS.UNIQ_867686DHDKJ97876) violada";
+      $justificativa = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea con";
 
       $parametros = new stdClass();
       $parametros->recusaDeTramite = new stdClass();

--- a/tests_sei5/funcional/tests/TramiteBlocoDeTramiteSituacaoProcessoConcluidoTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoDeTramiteSituacaoProcessoConcluidoTest.php
@@ -70,7 +70,6 @@ class TramiteBlocoDeTramiteSituacaoProcessoConcluidoTest extends FixtureCenarioB
     $estadoEsperado = mb_convert_encoding('Concluído', 'UTF-8', 'ISO-8859-1');
 
     $this->waitUntil(function() use ($objProtocoloDTO, $estadoEsperado) {
-      sleep(5);
       $this->paginaBase->refresh();
 
       $colunasEstado = $this->paginaCadastrarProcessoEmBloco->elementsByXPath('//table[@id="tblBlocos"]/tbody/tr/td[3]');
@@ -138,8 +137,10 @@ class TramiteBlocoDeTramiteSituacaoProcessoConcluidoTest extends FixtureCenarioB
     $this->paginaCadastrarProcessoEmBloco->navegarListagemBlocoDeTramite();
     $this->paginaCadastrarProcessoEmBloco->bntTramitarBloco();
     $this->paginaCadastrarProcessoEmBloco->tramitarProcessoExternamente(
-      self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-      self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false,
+      self::$destinatario['REP_ESTRUTURAS'], 
+      self::$destinatario['NOME_UNIDADE'],
+      self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+      false,
       function () {
         try {
             $this->paginaCadastrarProcessoEmBloco->frame('ifrEnvioProcesso');
@@ -156,7 +157,9 @@ class TramiteBlocoDeTramiteSituacaoProcessoConcluidoTest extends FixtureCenarioB
         }
 
         return true;
-      }
+      },
+    PEN_WAIT_TIMEOUT,
+    false 
     );
 
     $this->paginaBase->navegarParaControleProcesso();
@@ -167,7 +170,6 @@ class TramiteBlocoDeTramiteSituacaoProcessoConcluidoTest extends FixtureCenarioB
     $this->paginaBase->navegarParaControleProcesso();
     $this->paginaCadastrarProcessoEmBloco->navegarListagemBlocoDeTramite();
     $this->waitUntil(function() use ($objProtocoloDTO) {
-      sleep(5);
       $this->paginaBase->refresh();
       $colunaEstado = $this->paginaBase->elementsByXPath('//table[@id="tblBlocos"]/tbody/tr/td[3]');
       $this->assertEquals(mb_convert_encoding("Concluído", 'UTF-8', 'ISO-8859-1'), $colunaEstado[0]->getText());
@@ -240,7 +242,6 @@ class TramiteBlocoDeTramiteSituacaoProcessoConcluidoTest extends FixtureCenarioB
     $estadoEsperado = mb_convert_encoding('Concluído', 'UTF-8', 'ISO-8859-1');
 
     $this->waitUntil(function() use ($objProtocoloDTO, $estadoEsperado) {
-      sleep(5);
       $this->paginaBase->refresh();
 
       $colunasEstado = $this->paginaCadastrarProcessoEmBloco->elementsByXPath('//table[@id="tblBlocos"]/tbody/tr/td[3]');

--- a/tests_sei5/funcional/tests/TramiteBlocoDeTramiteSituacaoProcessoTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoDeTramiteSituacaoProcessoTest.php
@@ -55,8 +55,10 @@ class TramiteBlocoDeTramiteSituacaoProcessoTest extends FixtureCenarioBaseTestCa
     $this->paginaCadastrarProcessoEmBloco->navegarListagemBlocoDeTramite();
     $this->paginaCadastrarProcessoEmBloco->bntTramitarBloco();
     $this->paginaCadastrarProcessoEmBloco->tramitarProcessoExternamente(
-      self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-      self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false,
+      self::$destinatario['REP_ESTRUTURAS'], 
+      self::$destinatario['NOME_UNIDADE'],
+      self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+      false,
       function () {
         try {
             $this->paginaCadastrarProcessoEmBloco->frame('ifrEnvioProcesso');
@@ -73,11 +75,12 @@ class TramiteBlocoDeTramiteSituacaoProcessoTest extends FixtureCenarioBaseTestCa
         }
 
         return true;
-      }
+      },
+      PEN_WAIT_TIMEOUT,
+      true
     );
 
     $this->waitUntil(function() use ($objProtocoloDTO) {
-      sleep(5);
       $this->paginaBase->refresh();
       $colunaEstado = $this->paginaBase->elementsByXPath('//table[@id="tblBlocos"]/tbody/tr/td[3]');
       $this->assertEquals("Aguardando Processamento", $colunaEstado[0]->getText());

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoComProcessoNaoMapeadoRecusaTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoComProcessoNaoMapeadoRecusaTest.php
@@ -94,7 +94,6 @@ class TramiteBlocoExternoComProcessoNaoMapeadoRecusaTest extends FixtureCenarioB
     $this->paginaCadastrarProcessoEmBloco->bntVisualizarProcessos();
 
     $this->waitUntil(function () {
-      sleep(5);
       $this->paginaBase->refresh();
       $linhasDaTabela = $this->paginaBase->elementsByXPath('//table[@id="tblBlocos"]/tbody/tr');
 
@@ -184,8 +183,17 @@ class TramiteBlocoExternoComProcessoNaoMapeadoRecusaTest extends FixtureCenarioB
     $this->paginaTramiteEmBloco->clicarSalvar();
 
     // Espera para a mensagem de sucesso aparecer
-    sleep(2);
-    $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
+    $mensagem = null;
+
+    $this->waitUntil(function() use (&$mensagem) {
+        try {
+            $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
+            return !empty($mensagem);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }, PEN_WAIT_TIMEOUT);
+    
     $this->assertStringContainsString(
       mb_convert_encoding('Processo(s) incluído(s) com sucesso no bloco ' . self::$objBlocoDeTramiteDTO2->getNumOrdem(), 'UTF-8', 'ISO-8859-1'),
       $mensagem

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoEstadoProcessosTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoEstadoProcessosTest.php
@@ -173,8 +173,21 @@ class TramiteBlocoExternoEstadoProcessosTest extends FixtureCenarioBaseTestCase
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();
       $this->paginaTramiteEmBloco->selecionarBloco($numIdBloco);
       $this->paginaTramiteEmBloco->clicarSalvar();
-
-      sleep(2);
-      return $this->paginaCadastrarProcessoEmBloco->buscarMensagemAlerta();
+      
+      return $this->aguardarEBuscarMensagemAlerta();
   }
+
+  private function aguardarEBuscarMensagemAlerta(): string
+    {
+        $this->waitUntil(function() {
+            try {
+                $mensagem = $this->paginaCadastrarProcessoEmBloco->buscarMensagemAlerta();
+                return !empty($mensagem);
+            } catch (\Exception $e) {
+                return false;
+            }
+        }, PEN_WAIT_TIMEOUT);
+
+        return $this->paginaCadastrarProcessoEmBloco->buscarMensagemAlerta();
+    }
 }

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoInclusaoDeProcessoEmBlocoComHipoteseLegalNaoMapeadaTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoInclusaoDeProcessoEmBlocoComHipoteseLegalNaoMapeadaTest.php
@@ -81,7 +81,7 @@ class TramiteBlocoExternoInclusaoDeProcessoEmBlocoComHipoteseLegalNaoMapeadaTest
       $this->paginaTramiteEmBloco->clicarSalvar();
 
       // Verificar se a mensagem de sucesso foi exibida
-      sleep(2);
+      sleep(1);
       $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
         
       // Validação: a mensagem de alerta deve conter a hipótese legal não mapeada
@@ -156,7 +156,7 @@ class TramiteBlocoExternoInclusaoDeProcessoEmBlocoComHipoteseLegalNaoMapeadaTest
       $this->paginaTramiteEmBloco->clicarSalvar();
 
       // Verificar se a mensagem de sucesso foi exibida
-      sleep(2);
+      sleep(1);
       $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
         
       // Validação: a mensagem de alerta deve conter a hipótese legal não mapeada

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoInclusaoDeProcessoPorVisualizacaoDetalhadaTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoInclusaoDeProcessoPorVisualizacaoDetalhadaTest.php
@@ -74,7 +74,7 @@ class TramiteBlocoExternoInclusaoDeProcessoPorVisualizacaoDetalhadaTest extends 
       $this->paginaTramiteEmBloco->clicarSalvar();
 
       // Espera para a mensagem de sucesso aparecer
-      sleep(2);
+      sleep(1);
       $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
       $this->assertStringContainsString(
           mb_convert_encoding('Processo(s) incluído(s) com sucesso no bloco ' . $objBlocoDeTramiteDTO->getNumOrdem(), 'UTF-8', 'ISO-8859-1'),

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoLimiteAnexoTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoLimiteAnexoTest.php
@@ -86,7 +86,7 @@ class TramiteBlocoExternoLimiteAnexoTest extends FixtureCenarioBaseTestCase
               return true;
             }
         );
-        sleep(10);
+        sleep(1);
     } else {
         $this->paginaCadastrarProcessoEmBloco->bntVisualizarProcessos();
         $qtyProcessos = $this->paginaCadastrarProcessoEmBloco->retornarQuantidadeDeProcessosNoBloco();

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoLimiteTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoLimiteTest.php
@@ -77,7 +77,6 @@ class TramiteBlocoExternoLimiteTest extends FixtureCenarioBaseTestCase
               return true;
             }
         );
-        sleep(5);
 
     } else {
         $this->paginaCadastrarProcessoEmBloco->bntVisualizarProcessos();
@@ -153,7 +152,6 @@ class TramiteBlocoExternoLimiteTest extends FixtureCenarioBaseTestCase
 
     if (self::$tramitar == true) {
       $this->waitUntil(function() {
-        sleep(5);
         $this->paginaBase->refresh();
         $novoStatus = $this->paginaCadastrarProcessoEmBloco->retornarTextoColunaDaTabelaDeBlocos();
         $this->assertNotEquals('Aguardando Processamento', $novoStatus);

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoProcessoJaIncluidoEmBlocoTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoProcessoJaIncluidoEmBlocoTest.php
@@ -44,7 +44,7 @@ class TramiteBlocoExternoProcessoJaIncluidoEmBlocoTest extends FixtureCenarioBas
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();
       $this->paginaTramiteEmBloco->selecionarBloco(self::$objBlocoDeTramiteDTO->getNumId());
       $this->paginaTramiteEmBloco->clicarSalvar();
-      sleep(2);
+      sleep(1);
       $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
       $this->assertStringContainsString(
           mb_convert_encoding('Processo(s) incluído(s) com sucesso no bloco ' . self::$objBlocoDeTramiteDTO->getNumOrdem(), 'UTF-8', 'ISO-8859-1'),
@@ -73,7 +73,7 @@ class TramiteBlocoExternoProcessoJaIncluidoEmBlocoTest extends FixtureCenarioBas
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();
       $this->paginaTramiteEmBloco->selecionarBloco(self::$objBlocoDeTramiteDTO->getNumId());
       $this->paginaTramiteEmBloco->clicarSalvar();
-      sleep(2);
+      sleep(1);
       $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
         
       $this->assertStringContainsString(

--- a/tests_sei5/funcional/tests/TramiteBlocoExternoUnidadeTest.php
+++ b/tests_sei5/funcional/tests/TramiteBlocoExternoUnidadeTest.php
@@ -52,7 +52,7 @@ class TramiteBlocoExternoUnidadeTest extends FixtureCenarioBaseTestCase
       $this->selecionarUnidadeInterna(self::$remetente['SIGLA_UNIDADE']);
 
       self::$objBlocoDeTramiteDTO = $this->cadastrarBlocoDeTramite();
-      sleep(2);
+      sleep(1);
 
       $this->paginaTramiteEmBloco->selecionarProcessos([self::$objProtocoloDTO->getStrProtocoloFormatado()]);
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();

--- a/tests_sei5/funcional/tests/TramiteEnvioParcialDocumentosExternosIguaisTest.php
+++ b/tests_sei5/funcional/tests/TramiteEnvioParcialDocumentosExternosIguaisTest.php
@@ -59,7 +59,10 @@ class TramiteEnvioParcialDocumentosExternosIguaisTest extends FixtureCenarioBase
       self::$destinatario['REP_ESTRUTURAS'],
       self::$destinatario['NOME_UNIDADE'],
       self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-      false
+      false,
+      null,
+      PEN_WAIT_TIMEOUT,
+      true
     );
 
     $this->sairSistema();
@@ -145,14 +148,15 @@ class TramiteEnvioParcialDocumentosExternosIguaisTest extends FixtureCenarioBase
 
     $this->paginaControleProcesso->abrirProcesso(self::$protocoloTestePrincipal->getStrProtocoloFormatado());
 
-    sleep(5);
-
     $this->tramitarProcessoExternamente(
       self::$protocoloTestePrincipal,
       self::$remetente['REP_ESTRUTURAS'],
       self::$remetente['NOME_UNIDADE'],
       self::$remetente['SIGLA_UNIDADE_HIERARQUIA'],
-      false
+      false,
+      null,
+      PEN_WAIT_TIMEOUT,
+      true
     );
 
     $this->sairSistema();

--- a/tests_sei5/funcional/tests/TramiteEnvioParcialProcessoContendoDocumentoMovidoDestinatarioTest.php
+++ b/tests_sei5/funcional/tests/TramiteEnvioParcialProcessoContendoDocumentoMovidoDestinatarioTest.php
@@ -62,17 +62,19 @@ class TramiteEnvioParcialProcessoContendoDocumentoMovidoDestinatarioTest extends
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->tramitarProcessoExternamente(
-            self::$protocoloTesteFormatado,
-            self::$destinatario['REP_ESTRUTURAS'],
-            self::$destinatario['NOME_UNIDADE'],
-            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+          self::$protocoloTesteFormatado,
+          self::$destinatario['REP_ESTRUTURAS'],
+          self::$destinatario['NOME_UNIDADE'],
+          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->waitUntil(function() {
-          sleep(5);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -138,17 +140,19 @@ class TramiteEnvioParcialProcessoContendoDocumentoMovidoDestinatarioTest extends
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->tramitarProcessoExternamente(
-            self::$protocoloTesteFormatado,
-            self::$remetente['REP_ESTRUTURAS'],
-            self::$remetente['NOME_UNIDADE'],
-            self::$remetente['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+          self::$protocoloTesteFormatado,
+          self::$remetente['REP_ESTRUTURAS'],
+          self::$remetente['NOME_UNIDADE'],
+          self::$remetente['SIGLA_UNIDADE_HIERARQUIA'],
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->waitUntil(function() {
-          sleep(5);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -179,17 +183,19 @@ class TramiteEnvioParcialProcessoContendoDocumentoMovidoDestinatarioTest extends
         $this->abrirProcesso(self::$protocoloTesteFormatado);       
 
         $this->tramitarProcessoExternamente(
-            self::$protocoloTesteFormatado,
-            self::$destinatario['REP_ESTRUTURAS'],
-            self::$destinatario['NOME_UNIDADE'],
-            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+          self::$protocoloTesteFormatado,
+          self::$destinatario['REP_ESTRUTURAS'],
+          self::$destinatario['NOME_UNIDADE'],
+          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->waitUntil(function() {
-          sleep(5);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteEnvioParcialProcessoContendoDocumentoMovidoTest.php
+++ b/tests_sei5/funcional/tests/TramiteEnvioParcialProcessoContendoDocumentoMovidoTest.php
@@ -84,18 +84,20 @@ class TramiteEnvioParcialProcessoContendoDocumentoMovidoTest extends FixtureCena
 
 
         $this->tramitarProcessoExternamente(
-            self::$protocoloTesteFormatado,
-            self::$destinatario['REP_ESTRUTURAS'],
-            self::$destinatario['NOME_UNIDADE'],
-            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+          self::$protocoloTesteFormatado,
+          self::$destinatario['REP_ESTRUTURAS'],
+          self::$destinatario['NOME_UNIDADE'],
+          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         
         $this->waitUntil(function() {
-          sleep(5);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -132,17 +134,19 @@ class TramiteEnvioParcialProcessoContendoDocumentoMovidoTest extends FixtureCena
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->tramitarProcessoExternamente(
-            self::$protocoloTesteFormatado,
-            self::$remetente['REP_ESTRUTURAS'],
-            self::$remetente['NOME_UNIDADE'],
-            self::$remetente['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+          self::$protocoloTesteFormatado,
+          self::$remetente['REP_ESTRUTURAS'],
+          self::$remetente['NOME_UNIDADE'],
+          self::$remetente['SIGLA_UNIDADE_HIERARQUIA'],
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->waitUntil(function() {
-          sleep(5);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -174,17 +178,19 @@ class TramiteEnvioParcialProcessoContendoDocumentoMovidoTest extends FixtureCena
         $this->abrirProcesso(self::$protocoloTesteFormatado);       
 
         $this->tramitarProcessoExternamente(
-            self::$protocoloTesteFormatado,
-            self::$destinatario['REP_ESTRUTURAS'],
-            self::$destinatario['NOME_UNIDADE'],
-            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+          self::$protocoloTesteFormatado,
+          self::$destinatario['REP_ESTRUTURAS'],
+          self::$destinatario['NOME_UNIDADE'],
+          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->waitUntil(function() {
-          sleep(5);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteEnvioParcialTest.php
+++ b/tests_sei5/funcional/tests/TramiteEnvioParcialTest.php
@@ -56,7 +56,10 @@ class TramiteEnvioParcialTest extends FixtureCenarioBaseTestCase
       self::$destinatario['REP_ESTRUTURAS'],
       self::$destinatario['NOME_UNIDADE'],
       self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-      false
+      false,
+      null,
+      PEN_WAIT_TIMEOUT,
+      true
     );
 
     $this->sairSistema();
@@ -83,7 +86,6 @@ class TramiteEnvioParcialTest extends FixtureCenarioBaseTestCase
 
     $this->paginaBase->navegarParaControleProcesso();
     $this->waitUntil(function() use ($strProtocoloTeste) {
-        sleep(5);
         try {
             $this->paginaBase->refresh();
             $this->paginaControleProcesso->abrirProcesso($strProtocoloTeste);
@@ -140,14 +142,15 @@ class TramiteEnvioParcialTest extends FixtureCenarioBaseTestCase
 
     $this->paginaControleProcesso->abrirProcesso(self::$protocoloTestePrincipal->getStrProtocoloFormatado());
 
-    sleep(5);
-
     $this->tramitarProcessoExternamente(
       self::$protocoloTestePrincipal,
       self::$remetente['REP_ESTRUTURAS'],
       self::$remetente['NOME_UNIDADE'],
       self::$remetente['SIGLA_UNIDADE_HIERARQUIA'],
-      false
+      false,
+      null,
+      PEN_WAIT_TIMEOUT,
+      true
     );
 
     $this->sairSistema();

--- a/tests_sei5/funcional/tests/TramiteProcessoAnexadoComDevolucaoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoAnexadoComDevolucaoTest.php
@@ -74,11 +74,14 @@ class TramiteProcessoAnexadoComDevolucaoTest extends FixtureCenarioBaseTestCase
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
         
   }
@@ -208,11 +211,14 @@ class TramiteProcessoAnexadoComDevolucaoTest extends FixtureCenarioBaseTestCase
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 

--- a/tests_sei5/funcional/tests/TramiteProcessoAnexadoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoAnexadoTest.php
@@ -73,11 +73,14 @@ class TramiteProcessoAnexadoTest extends FixtureCenarioBaseTestCase
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
         
   }

--- a/tests_sei5/funcional/tests/TramiteProcessoBlocoDeTramitePermissoesTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoBlocoDeTramitePermissoesTest.php
@@ -96,7 +96,6 @@ class TramiteProcessoBlocoDeTramitePermissoesTest extends FixtureCenarioBaseTest
 
       $this->paginaProcesso->selecionarProcesso();
       $this->paginaProcesso->navegarParaOrdenarDocumentos();
-      sleep(1);
       $this->paginaProcesso->trocarOrdenacaoDocumentos();
 
       // Validação dos dados do processo principal
@@ -109,7 +108,6 @@ class TramiteProcessoBlocoDeTramitePermissoesTest extends FixtureCenarioBaseTest
         // Ignora a exceção se a imagem não for encontrada]
         print_r($listaDocumentosProcesso);
     }
-      sleep(1);
       $this->sairSistema();
 
   }
@@ -163,7 +161,6 @@ class TramiteProcessoBlocoDeTramitePermissoesTest extends FixtureCenarioBaseTest
 
       $this->paginaCadastrarProcessoEmBloco->navegarListagemBlocoDeTramite();
       $this->paginaCadastrarProcessoEmBloco->bntVisualizarProcessos();
-      sleep(1);
         
       // Executa remoção de protocolos do bloco e verifica status
       $this->paginaCadastrarProcessoEmBloco->btnSelecionarTodosProcessos();
@@ -171,7 +168,6 @@ class TramiteProcessoBlocoDeTramitePermissoesTest extends FixtureCenarioBaseTest
       $qtdProcessoBloco = $this->paginaCadastrarProcessoEmBloco->retornarQuantidadeDeProcessosNoBloco();
       $this->assertEquals($qtdProcessoBloco, 0);
       $this->paginaCadastrarProcessoEmBloco->btnComandoSuperiorFechar();
-      sleep(1);
 
       // $linhasDaTabela = $this->elements($this->using('xpath')->value('//table[@id="tblBlocos"]/tbody/tr'));
 
@@ -253,7 +249,7 @@ class TramiteProcessoBlocoDeTramitePermissoesTest extends FixtureCenarioBaseTest
       $this->paginaCadastrarProcessoEmBloco->bntVisualizarProcessos();
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
           $selector = sprintf(
               '#tblBlocos tbody tr td:nth-child(7) img[title="%s"]',
@@ -295,8 +291,6 @@ class TramiteProcessoBlocoDeTramitePermissoesTest extends FixtureCenarioBaseTest
       $qtdProcessoBlocoPos = $this->paginaCadastrarProcessoEmBloco->retornarQuantidadeDeProcessosNoBloco(); 
 
       $this->assertEquals($qtdProcessoBloco, $qtdProcessoBlocoPos);
-
-      sleep(2);
 
       $this->sairSistema();
   }

--- a/tests_sei5/funcional/tests/TramiteProcessoBlocoDeTramiteRegrasTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoBlocoDeTramiteRegrasTest.php
@@ -47,14 +47,13 @@ class TramiteProcessoBlocoDeTramiteRegrasTest extends FixtureCenarioBaseTestCase
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();
       $this->paginaTramiteEmBloco->selecionarBloco(self::$objBlocoDeTramiteDTO->getNumId());
       $this->paginaTramiteEmBloco->clicarSalvar();
-      sleep(2);
 
       $mensagem = "Prezado(a) usuário(a), o processo " . $objProtocoloDTO->getStrProtocoloFormatado()
           . " possui documentos gerados não assinados. "
           . "Dessa forma, não foi possível realizar sua inserção no bloco selecionado.";
       $this->assertStringContainsString(
           mb_convert_encoding($mensagem, 'UTF-8', 'ISO-8859-1'),
-          $this->paginaTramiteEmBloco->buscarMensagemAlerta()
+          $this->aguardarEBuscarMensagemAlerta()
       );
   }
 
@@ -89,9 +88,8 @@ class TramiteProcessoBlocoDeTramiteRegrasTest extends FixtureCenarioBaseTestCase
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();
       $this->paginaTramiteEmBloco->selecionarBloco(self::$objBlocoDeTramiteDTO->getNumId());
       $this->paginaTramiteEmBloco->clicarSalvar();
-      sleep(2);
 
-      $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
+      $mensagem = $this->aguardarEBuscarMensagemAlerta();
       $this->assertStringContainsString(
           mb_convert_encoding('Prezado(a) usuário(a), o processo ' . $objProtocoloDTO->getStrProtocoloFormatado() . ' encontra-se bloqueado. Dessa forma, não foi possível realizar a sua inserção no bloco selecionado.', 'UTF-8', 'ISO-8859-1'),
           $mensagem
@@ -130,9 +128,8 @@ class TramiteProcessoBlocoDeTramiteRegrasTest extends FixtureCenarioBaseTestCase
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();
       $this->paginaTramiteEmBloco->selecionarBloco(self::$objBlocoDeTramiteDTO->getNumId());
       $this->paginaTramiteEmBloco->clicarSalvar();
-      sleep(2);
 
-      $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
+      $mensagem = $this->aguardarEBuscarMensagemAlerta();
       $this->assertStringContainsString(
           mb_convert_encoding('Não é possível tramitar um processo aberto em mais de uma unidade.', 'UTF-8', 'ISO-8859-1'),
           $mensagem
@@ -165,13 +162,26 @@ class TramiteProcessoBlocoDeTramiteRegrasTest extends FixtureCenarioBaseTestCase
       $this->paginaTramiteEmBloco->selecionarTramiteEmBloco();
       $this->paginaTramiteEmBloco->selecionarBloco(self::$objBlocoDeTramiteDTO->getNumId());
       $this->paginaTramiteEmBloco->clicarSalvar();
-      sleep(2);
 
       $mensagem = "Prezado(a) usuário(a), o processo " . $objProtocoloDTO->getStrProtocoloFormatado()
           . " não possui documentos. Dessa forma, não foi possível realizar sua inserção no bloco selecionado.";
       $this->assertStringContainsString(
           mb_convert_encoding($mensagem, 'UTF-8', 'ISO-8859-1'),
-          $this->paginaTramiteEmBloco->buscarMensagemAlerta()
+          $this->aguardarEBuscarMensagemAlerta()
       );
+  }
+
+  private function aguardarEBuscarMensagemAlerta(): string
+  {
+      $this->waitUntil(function() {
+          try {
+              $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
+              return !empty($mensagem);
+          } catch (\Exception $e) {
+              return false;
+          }
+      }, PEN_WAIT_TIMEOUT);
+
+      return $this->paginaTramiteEmBloco->buscarMensagemAlerta();
   }
 }

--- a/tests_sei5/funcional/tests/TramiteProcessoComCancelamentoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoComCancelamentoTest.php
@@ -34,7 +34,13 @@ class TramiteProcessoComCancelamentoTest extends FixtureCenarioBaseTestCase
       self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
       self::$documentoTeste = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
 
-      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
+      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(
+        self::$processoTeste, 
+        self::$documentoTeste, 
+        self::$remetente, 
+        self::$destinatario, 
+        false
+      );
       self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
 
       $this->paginaProcesso->cancelarTramitacaoExterna();
@@ -90,7 +96,13 @@ class TramiteProcessoComCancelamentoTest extends FixtureCenarioBaseTestCase
       self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
       self::$documentoTeste = $this->gerarDadosDocumentoExternoTeste(self::$remetente, 'arquivo_001.pdf');
 
-      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
+      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(
+        self::$processoTeste, 
+        self::$documentoTeste, 
+        self::$remetente, 
+        self::$destinatario,
+        false
+      );
       self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
 
       $this->paginaProcesso->cancelarTramitacaoExterna();

--- a/tests_sei5/funcional/tests/TramiteProcessoComDevolucaoAnexadoOutroTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoComDevolucaoAnexadoOutroTest.php
@@ -123,11 +123,14 @@ class TramiteProcessoComDevolucaoAnexadoOutroTest extends FixtureCenarioBaseTest
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 

--- a/tests_sei5/funcional/tests/TramiteProcessoComDevolucaoContendoOutroAnexadoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoComDevolucaoContendoOutroAnexadoTest.php
@@ -110,11 +110,14 @@ class TramiteProcessoComDevolucaoContendoOutroAnexadoTest extends FixtureCenario
       $this->abrirProcesso(self::$protocoloTestePrincipal);
 
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 

--- a/tests_sei5/funcional/tests/TramiteProcessoComDocumentoRestritoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoComDocumentoRestritoTest.php
@@ -67,7 +67,10 @@ class TramiteProcessoComDocumentoRestritoTest extends FixtureCenarioBaseTestCase
       self::$destinatario['REP_ESTRUTURAS'],
       self::$destinatario['NOME_UNIDADE'],
       self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-      false
+      false,
+      null,
+      PEN_WAIT_TIMEOUT,
+      true
     );
 
 

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoCanceladoSemTamanhoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoCanceladoSemTamanhoTest.php
@@ -57,11 +57,14 @@ class TramiteProcessoContendoDocumentoCanceladoSemTamanhoTest extends FixtureCen
         
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTeste,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTeste,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 
@@ -83,7 +86,7 @@ class TramiteProcessoContendoDocumentoCanceladoSemTamanhoTest extends FixtureCen
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoCanceladoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoCanceladoTest.php
@@ -60,11 +60,14 @@ class TramiteProcessoContendoDocumentoCanceladoTest extends FixtureCenarioBaseTe
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTeste,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTeste,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 
@@ -86,7 +89,7 @@ class TramiteProcessoContendoDocumentoCanceladoTest extends FixtureCenarioBaseTe
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -172,11 +175,14 @@ class TramiteProcessoContendoDocumentoCanceladoTest extends FixtureCenarioBaseTe
       $this->abrirProcesso(self::$protocoloTeste);
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTeste,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTeste,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 
@@ -198,7 +204,7 @@ class TramiteProcessoContendoDocumentoCanceladoTest extends FixtureCenarioBaseTe
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoMesmoOrgaoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoMesmoOrgaoTest.php
@@ -53,7 +53,7 @@ class TramiteProcessoContendoDocumentoExternoMesmoOrgaoTest extends FixtureCenar
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoParticionadoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoParticionadoTest.php
@@ -74,8 +74,14 @@ class TramiteProcessoContendoDocumentoExternoParticionadoTest extends FixtureCen
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->tramitarProcessoExternamente(
-          self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false, null, PEN_WAIT_TIMEOUT_ARQUIVOS_GRANDES
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false, 
+        null, 
+        PEN_WAIT_TIMEOUT_ARQUIVOS_GRANDES,
+        true
       );
   }
 
@@ -101,7 +107,7 @@ class TramiteProcessoContendoDocumentoExternoParticionadoTest extends FixtureCen
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoTest.php
@@ -16,6 +16,26 @@ class TramiteProcessoContendoDocumentoExternoTest extends FixtureCenarioBaseTest
   public static $documentoTeste;
   public static $protocoloTeste;
 
+
+
+   /**
+     * @inheritdoc
+     * @return void
+     */
+    function setUp(): void
+    {
+        parent::setUp();
+
+        $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);    
+        $bancoOrgaoA->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasEnvioPEN'));
+        $bancoOrgaoA->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasRecebimentoPEN'));
+
+        $bancoOrgaoB = new DatabaseUtils(CONTEXTO_ORGAO_B);
+        $bancoOrgaoB->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasEnvioPEN'));
+        $bancoOrgaoB->execute("update infra_agendamento_tarefa set sin_ativo = ? where comando = ?", array('N', 'PENAgendamentoRN::processarTarefasRecebimentoPEN'));
+
+    }
+
     /**
      * Teste de trâmite externo de processo contendo apenas um documento externo
      *
@@ -34,7 +54,7 @@ class TramiteProcessoContendoDocumentoExternoTest extends FixtureCenarioBaseTest
       self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
       self::$documentoTeste = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
 
-      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
+      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);  
       self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
   }
 
@@ -59,7 +79,7 @@ class TramiteProcessoContendoDocumentoExternoTest extends FixtureCenarioBaseTest
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoGeradoMesmoOrgaoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoGeradoMesmoOrgaoTest.php
@@ -54,7 +54,7 @@ class TramiteProcessoContendoDocumentoGeradoMesmoOrgaoTest extends FixtureCenari
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoGeradoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoGeradoTest.php
@@ -49,8 +49,15 @@ class TramiteProcessoContendoDocumentoGeradoTest extends FixtureCenarioBaseTestC
 
       // 5 - Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-              self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-              self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
   }
 
 
@@ -74,7 +81,7 @@ class TramiteProcessoContendoDocumentoGeradoTest extends FixtureCenarioBaseTestC
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoInternoExternoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoInternoExternoTest.php
@@ -53,8 +53,15 @@ class TramiteProcessoContendoDocumentoInternoExternoTest extends FixtureCenarioB
 
       // 6 - Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-              self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-              self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
   }
 
 
@@ -78,7 +85,7 @@ class TramiteProcessoContendoDocumentoInternoExternoTest extends FixtureCenarioB
 
       // 7 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoDestinoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoDestinoTest.php
@@ -103,12 +103,21 @@ class TramiteProcessoContendoDocumentoMovidoDestinoTest extends FixtureCenarioBa
       $this->abrirProcesso(self::$protocoloTestePrincipal);
 
       // 5-tramitar Processo Principal para o Órgão 2 com validação no remetente
-      $this->tramitarProcessoExternamente(self::$protocoloTestePrincipal, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'], self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+      $this->tramitarProcessoExternamente(
+          self::$protocoloTestePrincipal, 
+          self::$destinatario['REP_ESTRUTURAS'], 
+          self::$destinatario['NOME_UNIDADE'], 
+          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
+      );
 
       // verificar se situação atual do processo está como bloqueado no remetente
       $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -195,12 +204,21 @@ class TramiteProcessoContendoDocumentoMovidoDestinoTest extends FixtureCenarioBa
       $this->cadastrarDocumentoInternoFixture(self::$documentoTeste5, self::$objProtocoloTestePrincipalOrg2DTO->getDblIdProtocolo());
         
       // 12-tramitar Processo Principal para o Órgão 1 com validação no remetente
-      $this->tramitarProcessoExternamente(self::$protocoloTestePrincipal, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'], self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+      $this->tramitarProcessoExternamente(
+        self::$protocoloTestePrincipal, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'], 
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
 
       // verificar se situação atual do processo está como bloqueado no remetente
       $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -259,12 +277,21 @@ class TramiteProcessoContendoDocumentoMovidoDestinoTest extends FixtureCenarioBa
       $this->abrirProcesso(self::$protocoloTestePrincipal);
 
       // 15-tramitar Processo Principal para o Órgão 2 com validação no remetente
-      $this->tramitarProcessoExternamente(self::$protocoloTestePrincipal, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'], self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+      $this->tramitarProcessoExternamente(
+        self::$protocoloTestePrincipal, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'], 
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
 
       // verificar se situação atual do processo está como bloqueado no remetente
       $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -323,12 +350,21 @@ class TramiteProcessoContendoDocumentoMovidoDestinoTest extends FixtureCenarioBa
       $this->abrirProcesso(self::$protocoloTestePrincipal);
 
       // 18-tramitar Processo Principal para o Órgão 1 com validação no remetente
-      $this->tramitarProcessoExternamente(self::$protocoloTestePrincipal, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'], self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+      $this->tramitarProcessoExternamente(
+        self::$protocoloTestePrincipal, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'], 
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
 
       // verificar se situação atual do processo está como bloqueado no remetente
       $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoEnvioDuploTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoEnvioDuploTest.php
@@ -94,14 +94,17 @@ class TramiteProcessoContendoDocumentoMovidoEnvioDuploTest extends FixtureCenari
             self::$destinatario['REP_ESTRUTURAS'],
             self::$destinatario['NOME_UNIDADE'],
             self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+            false,
+            null,
+            PEN_WAIT_TIMEOUT,
+            true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         
         $this->waitUntil(function () {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -140,13 +143,16 @@ class TramiteProcessoContendoDocumentoMovidoEnvioDuploTest extends FixtureCenari
             self::$remetente['REP_ESTRUTURAS'],
             self::$remetente['NOME_UNIDADE'],
             self::$remetente['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+            false,
+            null,
+            PEN_WAIT_TIMEOUT,
+            true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->waitUntil(function () {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -179,13 +185,16 @@ class TramiteProcessoContendoDocumentoMovidoEnvioDuploTest extends FixtureCenari
             self::$destinatario['REP_ESTRUTURAS'],
             self::$destinatario['NOME_UNIDADE'],
             self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-            false
+            false,
+            null,
+            PEN_WAIT_TIMEOUT,
+            true
         );
 
         $this->abrirProcesso(self::$protocoloTesteFormatado);
 
         $this->waitUntil(function () {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try {
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoSemAnexoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoSemAnexoTest.php
@@ -87,7 +87,10 @@ class TramiteProcessoContendoDocumentoMovidoSemAnexoTest extends FixtureCenarioB
       self::$destinatario['REP_ESTRUTURAS'],
       self::$destinatario['NOME_UNIDADE'],
       self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-      false
+      false,
+      null,
+      PEN_WAIT_TIMEOUT,
+      true
     );
   }
 
@@ -114,7 +117,7 @@ class TramiteProcessoContendoDocumentoMovidoSemAnexoTest extends FixtureCenarioB
     $this->paginaBase->pesquisar(self::$protocoloTeste->getStrProtocoloFormatado());
 
     $this->waitUntil(function() use (&$orgaosDiferentes) {
-      sleep(5);
+      sleep(2);
       $this->paginaBase->refresh();
       try { 
           $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -238,7 +241,10 @@ class TramiteProcessoContendoDocumentoMovidoSemAnexoTest extends FixtureCenarioB
       self::$destinatario['REP_ESTRUTURAS'],
       self::$destinatario['NOME_UNIDADE'],
       self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-      false
+      false,
+      null,
+      PEN_WAIT_TIMEOUT,
+      true
     );
   }
 
@@ -265,7 +271,7 @@ class TramiteProcessoContendoDocumentoMovidoSemAnexoTest extends FixtureCenarioB
     $this->paginaBase->pesquisar(self::$protocoloTeste->getStrProtocoloFormatado());
 
     $this->waitUntil(function() use (&$orgaosDiferentes) {
-      sleep(5);
+      sleep(2);
       $this->paginaBase->refresh();
       try { 
           $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoMovidoTest.php
@@ -70,7 +70,10 @@ class TramiteProcessoContendoDocumentoMovidoTest extends FixtureCenarioBaseTestC
           self::$destinatario['REP_ESTRUTURAS'],
           self::$destinatario['NOME_UNIDADE'],
           self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
       );
   }
 
@@ -92,7 +95,7 @@ class TramiteProcessoContendoDocumentoMovidoTest extends FixtureCenarioBaseTestC
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -200,7 +203,10 @@ class TramiteProcessoContendoDocumentoMovidoTest extends FixtureCenarioBaseTestC
           self::$destinatario['REP_ESTRUTURAS'],
           self::$destinatario['NOME_UNIDADE'],
           self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+          false,
+          null,
+          PEN_WAIT_TIMEOUT,
+          true
       );
   }
 
@@ -223,7 +229,7 @@ class TramiteProcessoContendoDocumentoMovidoTest extends FixtureCenarioBaseTestC
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoVariosDocumentosTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoVariosDocumentosTest.php
@@ -69,7 +69,7 @@ class TramiteProcessoContendoVariosDocumentosTest extends FixtureCenarioBaseTest
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoDocumentoNaoMapeadoDestinoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoDocumentoNaoMapeadoDestinoTest.php
@@ -71,7 +71,7 @@ class TramiteProcessoDocumentoNaoMapeadoDestinoTest extends FixtureCenarioBaseTe
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function()  {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringContainsString(mb_convert_encoding("Processo aberto somente na unidade", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoDocumentoNaoMapeadoOrigemTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoDocumentoNaoMapeadoOrigemTest.php
@@ -61,7 +61,16 @@ class TramiteProcessoDocumentoNaoMapeadoOrigemTest extends FixtureCenarioBaseTes
       $tipoDocumento = mb_convert_encoding(self::$documentoTeste["TIPO_DOCUMENTO"], "ISO-8859-1");
       $mensagemEsperada = sprintf("Não existe mapeamento de envio para %s no documento", $tipoDocumento);
       $this->expectExceptionMessage(mb_convert_encoding($mensagemEsperada, 'UTF-8', 'ISO-8859-1'));
-      $this->tramitarProcessoExternamente(self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'], self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+      $this->tramitarProcessoExternamente(
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'], 
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
   }
 
 
@@ -97,7 +106,16 @@ class TramiteProcessoDocumentoNaoMapeadoOrigemTest extends FixtureCenarioBaseTes
       $tipoDocumento = mb_convert_encoding(self::$documentoTeste["TIPO_DOCUMENTO"], "ISO-8859-1");
       $mensagemEsperada = sprintf("Não existe mapeamento de envio para %s no documento", $tipoDocumento);
       $this->expectExceptionMessage(mb_convert_encoding($mensagemEsperada, 'UTF-8', 'ISO-8859-1'));
-      $this->tramitarProcessoExternamente(self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'], self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+      $this->tramitarProcessoExternamente(
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'], 
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
       $this->sairSistema();
   }
 }

--- a/tests_sei5/funcional/tests/TramiteProcessoExtensaoNaoMapeadoDestinoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoExtensaoNaoMapeadoDestinoTest.php
@@ -58,7 +58,7 @@ class TramiteProcessoExtensaoNaoMapeadoDestinoTest extends FixtureCenarioBaseTes
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function()  {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringContainsString(mb_convert_encoding("Processo aberto somente na unidade", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoRestritoHipotesePadraoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoRestritoHipotesePadraoTest.php
@@ -53,8 +53,15 @@ class TramiteProcessoRestritoHipotesePadraoTest extends FixtureCenarioBaseTestCa
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-              self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-              self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
   }
 
 
@@ -78,7 +85,7 @@ class TramiteProcessoRestritoHipotesePadraoTest extends FixtureCenarioBaseTestCa
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoRestritoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoRestritoTest.php
@@ -54,8 +54,15 @@ class TramiteProcessoRestritoTest extends FixtureCenarioBaseTestCase
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-              self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-              self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
   }
 
 
@@ -79,7 +86,7 @@ class TramiteProcessoRestritoTest extends FixtureCenarioBaseTestCase
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoSemDadosBlocoDeTramiteTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoSemDadosBlocoDeTramiteTest.php
@@ -48,7 +48,11 @@ class TramiteProcessoSemDadosBlocoDeTramiteTest extends FixtureCenarioBaseTestCa
       $this->paginaTramiteEmBloco->selecionarBloco($objBlocoDeTramiteDTO->getNumId());
       $this->paginaTramiteEmBloco->clicarSalvar();
 
-      sleep(2);
+      $this->waitUntil(function() {
+          $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
+          return !empty($mensagem);
+      }, PEN_WAIT_TIMEOUT);
+
 
       $mensagem = $this->paginaTramiteEmBloco->buscarMensagemAlerta();
         

--- a/tests_sei5/funcional/tests/TramiteProcessoTamanhoAcimaLimiteDestinoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoTamanhoAcimaLimiteDestinoTest.php
@@ -68,8 +68,15 @@ class TramiteProcessoTamanhoAcimaLimiteDestinoTest extends FixtureCenarioBaseTes
       $this->abrirProcesso(self::$protocoloTeste);
 
       $this->tramitarProcessoExternamente(
-              self::$protocoloTeste, self::$destinatario['REP_ESTRUTURAS'], self::$destinatario['NOME_UNIDADE'],
-              self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false);
+        self::$protocoloTeste, 
+        self::$destinatario['REP_ESTRUTURAS'], 
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
+      );
       $this->sairSistema();
   }
 
@@ -93,7 +100,7 @@ class TramiteProcessoTamanhoAcimaLimiteDestinoTest extends FixtureCenarioBaseTes
 
       // 6 - Verificar se situação atual do processo está como bloqueado
       $this->waitUntil(function()  {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringContainsString(mb_convert_encoding("Processo aberto somente na unidade", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessoValidacaoEnvioTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoValidacaoEnvioTest.php
@@ -53,10 +53,14 @@ class TramiteProcessoValidacaoEnvioTest extends FixtureCenarioBaseTestCase
 
       $this->expectExceptionMessage(mb_convert_encoding("Não é possível tramitar um processo sem documentos", 'UTF-8', 'ISO-8859-1'));
       $this->tramitarProcessoExternamente(
-          self::$protocoloTeste,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], false
+        self::$protocoloTeste,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'], 
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 }

--- a/tests_sei5/funcional/tests/TramiteProcessosComDevolucaoAmbosAnexadosTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessosComDevolucaoAmbosAnexadosTest.php
@@ -126,11 +126,14 @@ class TramiteProcessosComDevolucaoAmbosAnexadosTest extends FixtureCenarioBaseTe
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 
@@ -154,7 +157,7 @@ class TramiteProcessosComDevolucaoAmbosAnexadosTest extends FixtureCenarioBaseTe
       $this->abrirProcesso(self::$protocoloTestePrincipal);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteProcessosComDevolucoesEAnexacoesTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessosComDevolucoesEAnexacoesTest.php
@@ -167,11 +167,14 @@ class TramiteProcessosComDevolucoesEAnexacoesTest extends FixtureCenarioBaseTest
         
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 
@@ -193,7 +196,7 @@ class TramiteProcessosComDevolucoesEAnexacoesTest extends FixtureCenarioBaseTest
       $this->abrirProcesso(self::$protocoloTestePrincipal);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
@@ -298,11 +301,14 @@ class TramiteProcessosComDevolucoesEAnexacoesTest extends FixtureCenarioBaseTest
 
       // Trâmitar Externamento processo para órgão/unidade destinatária
       $this->tramitarProcessoExternamente(
-          self::$protocoloTestePrincipal,
-          self::$destinatario['REP_ESTRUTURAS'],
-          self::$destinatario['NOME_UNIDADE'],
-          self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
-          false
+        self::$protocoloTestePrincipal,
+        self::$destinatario['REP_ESTRUTURAS'],
+        self::$destinatario['NOME_UNIDADE'],
+        self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+        false,
+        null,
+        PEN_WAIT_TIMEOUT,
+        true
       );
   }
 
@@ -324,7 +330,7 @@ class TramiteProcessosComDevolucoesEAnexacoesTest extends FixtureCenarioBaseTest
       $this->abrirProcesso(self::$protocoloTestePrincipal);
 
       $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(5);
+          sleep(2);
           $this->paginaBase->refresh();
         try { 
             $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());

--- a/tests_sei5/funcional/tests/TramiteRecebimentoDocumentoAnexadoTest.php
+++ b/tests_sei5/funcional/tests/TramiteRecebimentoDocumentoAnexadoTest.php
@@ -67,7 +67,11 @@ class TramiteRecebimentoDocumentoAnexadoTest extends FixtureCenarioBaseTestCase
       $novoTramite = $this->enviarMetadadosProcesso(self::$remetente, self::$destinatario, $processoTeste);
       $this->enviarComponentesDigitaisDoTramite($novoTramite, $processoTeste);
       $reciboTramiteEnvio = $this->receberReciboEnvio($novoTramite);
-         
+
+      // Processar pendências para que o processo chegue ao destinatário
+      if (DESATIVAR_AGENDAMENTO == 'true') {
+        $this->executarTramitarPendenciasSimples();
+      }
 
       //Verificar recebimento de novo processo administrativo contendo documento avulso enviado
       $this->assertNotNull($novoTramite);
@@ -94,7 +98,13 @@ class TramiteRecebimentoDocumentoAnexadoTest extends FixtureCenarioBaseTestCase
       self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
 
       $arrDocumentosSegundoEnvio = array(self::$documentoTeste4, self::$documentoTeste5);
-      $this->realizarTramiteExternoComValidacaoNoRemetenteFixture(self::$processoTeste, $arrDocumentosSegundoEnvio, self::$remetente, self::$destinatario);
+      $this->realizarTramiteExternoComValidacaoNoRemetenteFixture(
+        self::$processoTeste, 
+        $arrDocumentosSegundoEnvio, 
+        self::$remetente, 
+        self::$destinatario,
+        true        
+      );
   }
 
     /**

--- a/tests_sei5/funcional/tests/TramiteRecebimentoDocumentoAvulsoTest.php
+++ b/tests_sei5/funcional/tests/TramiteRecebimentoDocumentoAvulsoTest.php
@@ -65,6 +65,11 @@ class TramiteRecebimentoDocumentoAvulsoTest extends FixtureCenarioBaseTestCase
       $this->enviarComponentesDigitaisDoTramite($novoTramite, $metadadosDocumentoTeste);
       $reciboTramite = $this->receberReciboEnvio($novoTramite);
 
+      // Processar pendências para que o processo chegue ao destinatário
+      if (DESATIVAR_AGENDAMENTO == 'true') {
+        $this->executarTramitarPendenciasSimples();
+      }
+
       //Verificar recebimento de novo processo administrativo contendo documento avulso enviado
       $this->assertNotNull($novoTramite);
       $this->assertNotNull($reciboTramite);
@@ -89,7 +94,8 @@ class TramiteRecebimentoDocumentoAvulsoTest extends FixtureCenarioBaseTestCase
       self::$documentoTeste3 = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
 
       $documentos = array(self::$documentoTeste2, self::$documentoTeste3);
-      putenv("DATABASE_HOST=org1-database");
+      putenv("DATABASE_HOST=org1-database");      
+      
       $this->realizarTramiteExternoComValidacaoNoRemetenteFixture(self::$processoTeste, $documentos, self::$remetente, self::$destinatario);
   }
 

--- a/tests_sei5/funcional/tests/TramiteRecebimentoInteressadosDuplicadosTest.php
+++ b/tests_sei5/funcional/tests/TramiteRecebimentoInteressadosDuplicadosTest.php
@@ -56,7 +56,11 @@ class TramiteRecebimentoInteressadosDuplicadosTest extends FixtureCenarioBaseTes
       $novoTramite = $this->enviarMetadadosProcesso(self::$remetente, self::$destinatario, $processoTeste);
       $this->enviarComponentesDigitaisDoTramite($novoTramite, $processoTeste);
       $reciboTramite = $this->receberReciboEnvio($novoTramite);
-         
+
+      // Processar pendências para que o processo chegue ao destinatário
+      if (DESATIVAR_AGENDAMENTO == 'true') {
+        $this->executarTramitarPendenciasSimples();
+      }         
 
       //Verifica recebimento de novo processo administrativo contendo documento avulso enviado
       $this->assertNotNull($novoTramite);

--- a/tests_sei5/funcional/tests/TramiteRecebimentoMultiplosComponentesDigitaisApenasPendentesTest.php
+++ b/tests_sei5/funcional/tests/TramiteRecebimentoMultiplosComponentesDigitaisApenasPendentesTest.php
@@ -74,7 +74,11 @@ class TramiteRecebimentoMultiplosComponentesDigitaisApenasPendentesTest extends 
 
       $this->enviarComponentesDigitaisDoProcesso($novoTramite, $metadadosProcessoTeste);
       $reciboTramite = $this->receberReciboEnvio($novoTramite);
-         
+
+      // Processar pendências para que o processo chegue ao destinatário
+      if (DESATIVAR_AGENDAMENTO == 'true') {
+        $this->executarTramitarPendenciasSimples();
+      }            
 
       //Verificar recebimento de novo processo administrativo contendo documento avulso enviado
       $this->assertNotNull($novoTramite);

--- a/tests_sei5/funcional/tests/TramiteRecebimentoMultiplosComponentesDigitaisArquivoMovidoTest.php
+++ b/tests_sei5/funcional/tests/TramiteRecebimentoMultiplosComponentesDigitaisArquivoMovidoTest.php
@@ -76,6 +76,11 @@ class TramiteRecebimentoMultiplosComponentesDigitaisArquivoMovidoTest extends Fi
         $this->enviarComponentesDigitaisDoProcesso($novoTramite, $metadadosProcessoTeste);
         $reciboTramite = $this->receberReciboEnvio($novoTramite);
 
+        // Processar pendências para que o processo chegue ao destinatário
+        if (DESATIVAR_AGENDAMENTO == 'true') {
+            $this->executarTramitarPendenciasSimples();
+        }
+
         //Verificar recebimento de novo processo administrativo contendo documento avulso enviado
         $this->assertNotNull($novoTramite);
         $this->assertNotNull($reciboTramite);

--- a/tests_sei5/funcional/tests/TramiteRecebimentoMultiplosComponentesDigitaisTest.php
+++ b/tests_sei5/funcional/tests/TramiteRecebimentoMultiplosComponentesDigitaisTest.php
@@ -78,7 +78,11 @@ class TramiteRecebimentoMultiplosComponentesDigitaisTest extends FixtureCenarioB
 
       $this->enviarComponentesDigitaisDoProcesso($novoTramite, $metadadosProcessoTeste);
       $reciboTramite = $this->receberReciboEnvio($novoTramite);
-         
+
+       // Processar pendências para que o processo chegue ao destinatário
+      if (DESATIVAR_AGENDAMENTO == 'true') {
+        $this->executarTramitarPendenciasSimples();
+      }         
 
       //Verificar recebimento de novo processo administrativo contendo documento avulso enviado
       $this->assertNotNull($novoTramite);
@@ -238,9 +242,12 @@ class TramiteRecebimentoMultiplosComponentesDigitaisTest extends FixtureCenarioB
       $metadadosDocumentoTeste = $this->construirMetadadosDocumentoAvulsoTeste($documentoTeste);
       $novoTramite = $this->enviarMetadadosDocumento($remetente, $destinatario, $metadadosDocumentoTeste);
       $this->enviarComponentesDigitaisDoDocumentoAvulso($novoTramite, $metadadosDocumentoTeste);
-      sleep(5);
       $reciboTramite = $this->receberReciboEnvio($novoTramite);
-         
+
+      // Processar pendências para que o processo chegue ao destinatário
+      if (DESATIVAR_AGENDAMENTO == 'true') {
+        $this->executarTramitarPendenciasSimples();
+      }         
 
       //Verificar recebimento de novo processo administrativo contendo documento avulso enviado
       $this->assertNotNull($novoTramite);


### PR DESCRIPTION
Refatora alguns testes que estava dando falso positivo e passa a chamar o comando "make tramitar-pendencias-simples" sob demanda, fazendo que não dê falsos positivos por execução do agendamento fora do tempo adequado.