### PR TITLE
fix: Erro identificado na tramitação de processos com documentos grandes

### DIFF
--- a/src/rn/PendenciasTramiteRN.php
+++ b/src/rn/PendenciasTramiteRN.php
@@ -13,6 +13,7 @@ class PendenciasTramiteRN extends InfraRN
     const CODIGO_EXECUCAO_ERRO = 1;
     const NUMERO_PROCESSOS_MONITORAMENTO = 10;
     const MAXIMO_PROCESSOS_MONITORAMENTO = 20;
+    const LOCK_TIMEOUT_SECONDS = 1800; // 30 minutos  
     const COMANDO_EXECUCAO_WORKER = '%s %s %s %s %s %s %s %s > %s 2>&1 &';
     // Envio
     const LOCALIZACAO_SCRIPT_WORKER_ENVIO = DIR_SEI_WEB . "/../scripts/mod-pen/MonitoramentoEnvioTarefasPEN.php";
@@ -98,7 +99,23 @@ class PendenciasTramiteRN extends InfraRN
             $this->gravarLogDebug($mensagemLog, 3);
 
             try {
-                  $this->receberPendenciaProcessamento($objPendenciaDTO, $parBolSegundoPlano);
+              $strChaveLock = 'PEN_LOCK_TRAMITE_' . $numIdTramite;
+              $objCache = CacheSEI::getInstance();
+
+              // Tenta obter lock para processamento do trâmite
+              if ($objCache->getAtributo($strChaveLock)) {
+                continue;
+              }
+
+              $objCache->setAtributo($strChaveLock, time(), self::LOCK_TIMEOUT_SECONDS);
+
+              usleep(100000); // 100ms
+
+              try {
+                $this->receberPendenciaProcessamento($objPendenciaDTO, $parBolSegundoPlano);
+              } finally {
+                $objCache->removerAtributo($strChaveLock);
+              }
             } catch (\Exception $e) {
                     $this->gravarAmostraErroLogSEI($e);
                     $this->gravarLogDebug(InfraException::inspecionar($e));

--- a/src/rn/PendenciasTramiteRN.php
+++ b/src/rn/PendenciasTramiteRN.php
@@ -102,7 +102,7 @@ class PendenciasTramiteRN extends InfraRN
               $strChaveLock = 'PEN_LOCK_TRAMITE_' . $numIdTramite;
               $objCache = CacheSEI::getInstance();
 
-              // Tenta obter lock para processamento do trÃ¢mite
+              // Tenta obter lock para processamento do trâmite
               if ($objCache->getAtributo($strChaveLock)) {
                 continue;
               }


### PR DESCRIPTION
Fixes #1180

  ## Descrição das Alterações

Esta alteração resolve o problema de concorrência e duplicidade no processamento dos trâmites de processos de grande porte pelo módulo do Barramento PEN.

Quando um processo possui documentos grandes, o tempo necessário para o download e processamento de seus componentes digitais é mais longo. Isso pode fazer com que o worker de monitoramento ou outros subprocessos em segundo plano tentem processar concorrentemente a mesma pendência de trâmite em uma execução subsequente, gerando conflitos de concorrência, erros de integridade/duplicidade e consequente recusa no recebimento (status de erro na API/inconsistência no recebimento).

  Para mitigar esse comportamento:

  • Implementou-se um mecanismo de Lock Distribuído baseado no  CacheSEI.
  • Cada trâmite ( `$numIdTramite` ) recebe um identificador único de lock ( `PEN_LOCK_TRAMITE_<IDT>` ) persistido no cache do SEI, com expiração padrão ( `LOCK_TIMEOUT_SECONDS` ) definida em 30 minutos (1800 segundos).
  • Se outro processo tentar rodar a mesma pendência enquanto o lock estiver ativo, ele saltará ( `continue` ) o registro evitando o reprocessamento paralelo.
  • O lock é liberado automaticamente dentro de uma estrutura  `finally`  ao término da execução do método `receberPendenciaProcessamento` .

## Alterações Realizadas
- PendenciasTramiteRN.php:
  - Criação da constante  `LOCK_TIMEOUT_SECONDS` com o valor de  1800.
  - Inclusão do controle de obtenção, retenção e liberação do lock via  CacheSEI  antes e após o método `receberPendenciaProcessamento($objPendenciaDTO, $parBolSegundoPlano)` .
  - Inclusão de um pequeno atraso ( `usleep(100000)` ) de 100ms para evitar eventuais race conditions no momento do registro do lock.