### PR TITLE
fix: padroniza mensagens e corrige crítica de tipo de processo ao desativar/excluir itens mapeados (Ref #153)

### DIFF
--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -640,7 +640,7 @@ class PENIntegracao extends SeiIntegracao
 
   protected function validarExcluirDesativarTipoDocumento($arrObjSerieAPI,  $strDesativarExcluir)
   {
-    $excecao = new InfraException();
+    $arrStrNome = [];
     foreach ($arrObjSerieAPI as $objSerieAPI) {
       $objPenRelTipoDocMapEnviadoDTO = new PenRelTipoDocMapEnviadoDTO();
       $objPenRelTipoDocMapEnviadoDTO->setNumIdSerie($objSerieAPI->getIdSerie());
@@ -657,9 +657,15 @@ class PENIntegracao extends SeiIntegracao
       $objPenRelTipoDocMapRecebidoDTO = $objPenRelTipoDocMapRecebidoRN->contar($objPenRelTipoDocMapRecebidoDTO);
       
       if ($objPenRelTipoDocMapRecebidoDTO > 0 || $objPenRelTipoDocMapEnviadoDTO > 0) {
-          $excecao->lancarValidacao('Prezado(a) usuário(a), você está tentando '.$strDesativarExcluir.' o tipo de documento "'. $objSerieAPI->getNome()
-          . '". Esse tipo de documento está mapeado em Administração -> Tramita GOV.BR -> Mapeamento de Tipos de Documentos -> Envio/Recebimento');
+          $arrStrNome[$objSerieAPI->getNome()] = $objSerieAPI->getNome();
       }
+    }
+          
+    if (count($arrStrNome) > 0) {
+        $strAcao = ($strDesativarExcluir == 'excluir') ? 'excluídos' : 'desativados';
+        $strMensagem = 'Os tipos de documentos abaixo não podem ser '.$strAcao.' porque são utilizados na Administração do módulo Tramita Gov:\n- '.implode('\n- ', $arrStrNome);
+        $objInfraException = new InfraException();
+        $objInfraException->lancarValidacao($strMensagem);
     }
   }
 
@@ -673,7 +679,7 @@ class PENIntegracao extends SeiIntegracao
 
   protected function validarExcluirDesativarUnidade($arrObjUnidadeAPI, $strDesativarExcluir)
   {
-    $excecao = new InfraException();
+    $arrStrSigla = [];
     foreach ($arrObjUnidadeAPI as $objUnidadeAPI) {
       $objPenUnidadeDTO = new PenUnidadeDTO();
       $objPenUnidadeDTO->setNumIdUnidade($objUnidadeAPI->getIdUnidade());
@@ -682,9 +688,15 @@ class PENIntegracao extends SeiIntegracao
       $objPenUnidadeRN = new PenUnidadeRN();
       $objPenUnidadeDTO = $objPenUnidadeRN->contar($objPenUnidadeDTO);
       if ($objPenUnidadeDTO > 0) {
-        $excecao->lancarValidacao('Prezado(a) usuário(a), você está tentando '.$strDesativarExcluir.' a unidade "'. $objUnidadeAPI->getSigla()
-        . '". Essa unidade está mapeada em Administração -> Tramita GOV.BR -> Mapeamento de Unidades -> Listar' );
+        $arrStrSigla[$objUnidadeAPI->getSigla()] = $objUnidadeAPI->getSigla();
       }
+    }
+
+    if (count($arrStrSigla) > 0) {
+        $strAcao = ($strDesativarExcluir == 'excluir') ? 'excluídas' : 'desativadas';
+        $strMensagem = 'As unidades abaixo não podem ser '.$strAcao.' porque são utilizadas na Administração do módulo Tramita Gov:\n- '.implode('\n- ', $arrStrSigla);
+        $objInfraException = new InfraException();
+        $objInfraException->lancarValidacao($strMensagem);
     }
   }
 
@@ -697,40 +709,15 @@ class PENIntegracao extends SeiIntegracao
   }
 
   protected function validarDesativarExcluirTipoProcesso($arrObjTipoProcedimentoDTO, $strDesativarExcluir) {
-    
-    $mensagem = "Prezado(a) usuário(a), você está tentando ".$strDesativarExcluir." um Tipo de Processo que se encontra mapeado para o(s) relacionamento(s) "
-    ."\"%s\". Para continuar com essa ação é necessário remover do(s) mapeamentos "
-    ."mencionados o Tipo de Processo: \"%s\".";
+
+    $strAcao = ($strDesativarExcluir == 'excluir') ? 'excluídos' : 'desativados';
+    $mensagem = 'Os tipos de processos abaixo não podem ser '.$strAcao.' porque são utilizados na Administração do módulo Tramita Gov:\n- %s';
 
     $objMapeamentoTipoProcedimentoRN = new PenMapTipoProcedimentoRN();
     $objMapeamentoTipoProcedimentoRN->validarAcaoTipoProcesso($arrObjTipoProcedimentoDTO, $mensagem);
 
-    $mensagem = 'Prezado(a) usuário(a), você está tentando '.$strDesativarExcluir.' o Tipo de Processo "%s" '
-      . 'que se encontra mapeado para o Tipo de Processo Padrão. '
-      . 'Para continuar com essa ação é necessário alterar o Tipo de Processo Padrão. '
-      . 'O Tipo de Processo padrão se encontra disponível em: '
-      . 'Administração -> Tramita GOV.BR -> Mapeamento de Tipos de Processo -> Relacionamento entre Unidades';
-
     $objPenParametroRN = new PenParametroRN();
     $objPenParametroRN->validarAcaoTipoProcessoPadrao($arrObjTipoProcedimentoDTO, $mensagem);
-
-    $exception = new InfraException();
-    foreach ($arrObjTipoProcedimentoDTO as $objProcedimento) {
-        $objPenParametroDTO = new PenParametroDTO();
-        $objPenParametroDTO->setStrNome('PEN_TIPO_PROCESSO_EXTERNO');
-        $objPenParametroDTO->setStrValor($objProcedimento->getIdTipoProcedimento());
-        $objPenParametroRN = new PenParametroRN();
-        $objPenParametroDTO = $objPenParametroRN->contar($objPenParametroDTO);
-
-        $objProcedimentoDTO = new ProcedimentoDTO();
-        $objProcedimentoDTO->setNumIdTipoProcedimento($objProcedimento->getIdTipoProcedimento());
-        $objProcedimentoRN = new ProcedimentoRN();
-        $objProcedimentoDTO = $objProcedimentoRN->contarRN0279($objProcedimentoDTO);
-
-      if ($objPenParametroDTO > 0 || $objProcedimentoDTO > 0) {
-          $exception->lancarValidacao('Existem processos utilizando o tipo de processo "'. $objProcedimento->getNome().'".');
-      }
-    }
   }
 
     /**

--- a/src/rn/PenMapTipoProcedimentoRN.php
+++ b/src/rn/PenMapTipoProcedimentoRN.php
@@ -144,7 +144,7 @@ class PenMapTipoProcedimentoRN extends InfraRN
       }
     }
     if (count($arrTipoProcedimento) > 0) {
-        $mensagem = sprintf($mensagem, implode('", "', $mapeamentos), implode('", "', $arrTipoProcedimento));
+        $mensagem = sprintf($mensagem, implode('\n- ', $arrTipoProcedimento));
         LogSEI::getInstance()->gravar($mensagem, LogSEI::$AVISO);
         $objInfraException = new InfraException();
         $objInfraException->adicionarValidacao($mensagem);

--- a/src/rn/PenParametroRN.php
+++ b/src/rn/PenParametroRN.php
@@ -221,12 +221,12 @@ class PenParametroRN extends InfraRN
             && $objPenParametroDTO->getStrValor() == $objTipoProcedimentoDTO->getIdTipoProcedimento()
         ) {
         $mapeamentos[$objTipoProcedimentoDTO->getIdTipoProcedimento()] =
-        $objTipoProcedimentoDTO->getIdTipoProcedimento() . '-' .  $objTipoProcedimentoDTO->getNome();
+        $objTipoProcedimentoDTO->getNome();
       }
     }
     
     if (count($mapeamentos) > 0) {
-        $mensagem = sprintf($mensagem, implode('", "', $mapeamentos));
+        $mensagem = sprintf($mensagem, implode('\n- ', $mapeamentos));
         LogSEI::getInstance()->gravar($mensagem, LogSEI::$AVISO);
         $objInfraException = new InfraException();
         $objInfraException->adicionarValidacao($mensagem);


### PR DESCRIPTION
### Descrição
Ajustes nas críticas de **desativar/excluir** Tipos de Processo, Tipos de Documento e Unidades usados na Administração do Tramita (#153).

### Correções

- **Tipo de Processo (validarDesativarExcluirTipoProcesso):** removida a validação baseada em contarRN0279() (existência de qualquer processo do tipo) — é responsabilidade do core e contraria o acordado na #153 (validar pelo mapeamento em "Parâmetros de Configuração"). Removida também a checagem duplicada/inalcançável de PEN_TIPO_PROCESSO_EXTERNO, já coberta por validarAcaoTipoProcessoPadrao.
- **Tipo de Documento e Unidade:** lançavam a exceção dentro do laço e só exibiam o 1º item; agora coletam todos e lançam uma única mensagem com a lista completa.
- **Mensagens:** padronizadas em cabeçalho único + lista.

### Formato

> Os tipos de documentos abaixo não podem ser excluídos porque são utilizados na Administração do módulo Tramita Gov:
> - Documento A
> - Documento B

(idem para tipos de processo; unidades no feminino: "não podem ser desativadas/excluídas... utilizadas". Separador **\n** já usado no core, ex.: **HipoteseLegalRN**.)