### PR TITLE
fix: FK md_pen_componente_digital -> anexo com ON DELETE SET NULL

### DIFF
--- a/src/bd/PenMetaBD.php
+++ b/src/bd/PenMetaBD.php
@@ -385,4 +385,49 @@ class PenMetaBD extends InfraMetaBD
     }
       return $this;
   }
+
+  /**
+   * Cria uma chave estrangeira definindo a acao de exclusao (ON DELETE),
+   * recurso nao oferecido por InfraMetaBD::adicionarChaveEstrangeira().
+   *
+   * Acoes tratadas: 'SET NULL' e 'CASCADE' (geram a clausula ON DELETE).
+   * Qualquer outro valor cria a FK sem clausula, ou seja, com o comportamento
+   * padrao RESTRICT/NO ACTION (compativel com Oracle, que nao aceita ON DELETE
+   * NO ACTION explicito). A sintaxe ON DELETE SET NULL e ON DELETE CASCADE e
+   * compativel com Oracle, MySQL/InnoDB, PostgreSQL e SQL Server.
+   *
+   * @param string $strNomeFK       Nome da constraint
+   * @param string $strTabela       Tabela filha
+   * @param array  $arrCampos       Colunas da FK na tabela filha
+   * @param string $strTabelaOrigem Tabela referenciada
+   * @param array  $arrCamposOrigem Colunas referenciadas
+   * @param string $strAcaoExclusao Acao ON DELETE (ex.: 'SET NULL', 'CASCADE')
+   * @param bool   $bolCriarIndice  Cria indice para as colunas da FK
+   * @return PenMetaBD
+   */
+  public function criarChaveEstrangeiraComExclusao($strNomeFK, $strTabela, $arrCampos, $strTabelaOrigem, $arrCamposOrigem, $strAcaoExclusao = '', $bolCriarIndice = false)
+    {
+
+    if($this->isChaveExiste($strTabela, $strNomeFK)) {
+        return $this;
+    }
+
+    if($bolCriarIndice) {
+        $this->criarIndice($strTabela, $strNomeFK, $arrCampos);
+    }
+
+      $strSql = 'alter table '.$strTabela
+        .' add constraint '.$strNomeFK
+        .' foreign key ('.implode(',', $arrCampos).')'
+        .' references '.$strTabelaOrigem.' ('.implode(',', $arrCamposOrigem).')';
+
+      $strAcao = strtoupper(trim($strAcaoExclusao));
+    if($strAcao === 'SET NULL' || $strAcao === 'CASCADE') {
+        $strSql .= ' on delete '.strtolower($strAcao);
+    }
+
+      $this->getObjInfraIBanco()->executarSql($strSql);
+
+      return $this;
+  }
 }

--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -2699,6 +2699,21 @@ class PenAtualizarSeiRN extends PenAtualizadorRN
       // Recria o índice único de id_serie na tabela md_pen_rel_doc_map_enviado
       $objMetaBanco->criarIndice('md_pen_rel_doc_map_enviado', 'ak1_rel_doc_map_enviado', ['id_serie'], true);
 
+      
+      //----------------------------------------------------------------------
+      // Correção da FK md_pen_componente_digital -> anexo para ON DELETE SET NULL.
+      // Sem isso, o expurgo definitivo de um anexo pela limpeza da lixeira falha.
+      //----------------------------------------------------------------------
+      $objMetaBanco->excluirChaveEstrangeira('md_pen_componente_digital', 'fk_md_pen_comp_dig_anexo');
+      $objMetaBanco->criarChaveEstrangeiraComExclusao(
+        'fk_md_pen_comp_dig_anexo',
+        'md_pen_componente_digital',
+        ['id_anexo'],
+        'anexo',
+        ['id_anexo'],
+        'SET NULL'
+      );
+
       $this->atualizarNumeroVersao("4.1.0");
   }
 


### PR DESCRIPTION
Sem ON DELETE, o expurgo de um anexo tramitado na limpeza da lixeira falhava com ORA-02292 e abortava a rotina inteira. Recria a FK fk_md_pen_comp_dig_anexo com ON DELETE SET NULL (id_anexo ja e anulavel), preservando os metadados do tramite.

- PenMetaBD::criarChaveEstrangeiraComExclusao() (novo helper)
- instalarV4100(): drop + recreate da FK; versao do modulo -> 4.1.0

Close #1211 