### PR TITLE
fix: bloqueia envio externo para unidade do mesmo órgão

### DIFF
--- a/src/pen_procedimento_expedir_validar.php
+++ b/src/pen_procedimento_expedir_validar.php
@@ -39,6 +39,16 @@ try {
       $objInfraException->adicionarValidacao('Informe Unidade de destino', $strProtocoloFormatado);
   }
 
+    $objPenParametroRN = new PenParametroRN();
+    $objExpedirProcedimentosRN->validarDestinoOrgaoRemetente(
+        $objInfraException,
+        $objPenParametroRN->getParametro('PEN_ID_REPOSITORIO_ORIGEM'),
+        $objExpedirProcedimentosRN->obterIdEstruturaUnidadeAtual(),
+        $_POST['selRepositorioEstruturas'] ?? null,
+        $_POST['hdnIdUnidade'] ?? null,
+        $strProtocoloFormatado
+    );
+
   if(!$objInfraException->contemValidacoes()) {
       $objProcedimentoDTO->setArrObjDocumentoDTO($objExpedirProcedimentosRN->listarDocumentos($dblIdProcedimento));
       $objProcedimentoDTO->setArrObjParticipanteDTO($objExpedirProcedimentosRN->listarInteressados($dblIdProcedimento));

--- a/src/pen_validar_expedir_lote.php
+++ b/src/pen_validar_expedir_lote.php
@@ -17,6 +17,9 @@ try {
   }    
 
     $objExpedirProcedimentosRN = new ExpedirProcedimentoRN();
+    $objPenParametroRN = new PenParametroRN();
+    $numIdRepositorioOrigem = $objPenParametroRN->getParametro('PEN_ID_REPOSITORIO_ORIGEM');
+    $numIdEstruturaOrigem = $objExpedirProcedimentosRN->obterIdEstruturaUnidadeAtual();
     $objExpedirProcedimentosRN->verificarProcessosAbertoNaUnidade($objInfraException, $arrProtocolosOrigem);
   if ($objInfraException->contemValidacoes()) {
       $arrErros = [];
@@ -57,6 +60,15 @@ try {
     if(!array_key_exists('hdnIdUnidade', $_POST) || empty($_POST['hdnIdUnidade'])) {
         $objInfraException->adicionarValidacao('Informe Unidade de destino', $strProtocoloFormatado);
     }
+
+      $objExpedirProcedimentosRN->validarDestinoOrgaoRemetente(
+          $objInfraException,
+          $numIdRepositorioOrigem,
+          $numIdEstruturaOrigem,
+          $_POST['selRepositorioEstruturas'] ?? null,
+          $_POST['hdnIdUnidade'] ?? null,
+          $strProtocoloFormatado
+      );
 
       $objProcedimentoDTO->setArrObjDocumentoDTO($objExpedirProcedimentosRN->listarDocumentos($dblIdProcedimento));
       $objProcedimentoDTO->setArrObjParticipanteDTO($objExpedirProcedimentosRN->listarInteressados($dblIdProcedimento));

--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -56,6 +56,7 @@ class ExpedirProcedimentoRN extends InfraRN
     protected $fnEventoEnvioMetadados;
     protected $objPenDebug;
     protected $objCacheMetadadosProtocolo=[];
+    protected $arrCacheHierarquiaEstruturas=[];
 
     protected $arrPenMimeTypes = ["application/pdf", "application/vnd.oasis.opendocument.text", "application/vnd.oasis.opendocument.formula", "application/vnd.oasis.opendocument.spreadsheet", "application/vnd.oasis.opendocument.presentation", "text/xml", "text/rtf", "text/html", "text/plain", "text/csv", "image/gif", "image/jpeg", "image/png", "image/svg+xml", "image/tiff", "image/bmp", "audio/mp4", "audio/midi", "audio/ogg", "audio/vnd.wave", "video/avi", "video/mpeg", "video/mp4", "video/ogg", "video/webm"];
 
@@ -2721,6 +2722,14 @@ class ExpedirProcedimentoRN extends InfraRN
         $objInfraException->adicionarValidacao('Unidade de destino não informado. ID do processo: '.$objExpedirProcedimentoDTO->getDblIdProcedimento().". ");
     }
 
+      $this->validarDestinoOrgaoRemetente(
+          $objInfraException,
+          $objExpedirProcedimentoDTO->getNumIdRepositorioOrigem(),
+          $objExpedirProcedimentoDTO->getNumIdUnidadeOrigem(),
+          $objExpedirProcedimentoDTO->getNumIdRepositorioDestino(),
+          $objExpedirProcedimentoDTO->getNumIdUnidadeDestino()
+      );
+
       //TODO: Validar se motivo de urgncia foi devidamente informado, caso expedio urgente
     if ($objExpedirProcedimentoDTO->getBolSinUrgente() && InfraString::isBolVazia($objExpedirProcedimentoDTO->getNumIdMotivoUrgencia())) {
         $objInfraException->adicionarValidacao('Motivo de urgência não informado. ID do processo: '.$objExpedirProcedimentoDTO->getDblIdProcedimento().". ");
@@ -2749,6 +2758,106 @@ class ExpedirProcedimentoRN extends InfraRN
           );
       }
     }
+  }
+
+  public function validarDestinoOrgaoRemetente(
+      InfraException $objInfraException,
+      $numIdRepositorioOrigem,
+      $numIdEstruturaOrigem,
+      $numIdRepositorioDestino,
+      $numIdEstruturaDestino,
+      $strAtributoValidacao = null
+  )
+    {
+    if (!InfraString::isBolVazia($numIdRepositorioOrigem) &&
+        !InfraString::isBolVazia($numIdEstruturaOrigem) &&
+        !InfraString::isBolVazia($numIdRepositorioDestino) &&
+        !InfraString::isBolVazia($numIdEstruturaDestino) &&
+        $this->estruturasPertencemAoMesmoOrgao(
+            $numIdRepositorioOrigem,
+            $numIdEstruturaOrigem,
+            $numIdRepositorioDestino,
+            $numIdEstruturaDestino
+        )) {
+        $strMensagem = 'Não é possível realizar o envio externo para o próprio órgão remetente. '
+            . 'Selecione o repositório de estruturas de outro órgão como destino.';
+
+      if (InfraString::isBolVazia($strAtributoValidacao)) {
+          $objInfraException->adicionarValidacao($strMensagem);
+      } else {
+          $objInfraException->adicionarValidacao($strMensagem, $strAtributoValidacao);
+      }
+    }
+  }
+
+  public function estruturasPertencemAoMesmoOrgao(
+      $numIdRepositorioOrigem,
+      $numIdEstruturaOrigem,
+      $numIdRepositorioDestino,
+      $numIdEstruturaDestino
+  )
+    {
+    if ((string) $numIdRepositorioOrigem !== (string) $numIdRepositorioDestino) {
+        return false;
+    }
+
+    if ((string) $numIdEstruturaOrigem === (string) $numIdEstruturaDestino) {
+        return true;
+    }
+
+      $arrHierarquiaOrigem = $this->obterIdentificadoresHierarquiaEstrutura(
+          $numIdRepositorioOrigem,
+          $numIdEstruturaOrigem
+      );
+      $arrHierarquiaDestino = $this->obterIdentificadoresHierarquiaEstrutura(
+          $numIdRepositorioDestino,
+          $numIdEstruturaDestino
+      );
+
+      return count(array_intersect($arrHierarquiaOrigem, $arrHierarquiaDestino)) > 0;
+  }
+
+  private function obterIdentificadoresHierarquiaEstrutura($numIdRepositorio, $numIdEstrutura)
+    {
+      $strChaveCache = (string) $numIdRepositorio.':'.(string) $numIdEstrutura;
+    if (isset($this->arrCacheHierarquiaEstruturas[$strChaveCache])) {
+        return $this->arrCacheHierarquiaEstruturas[$strChaveCache];
+    }
+
+      $objEstrutura = $this->objProcessoEletronicoRN->consultarEstrutura(
+          $numIdRepositorio,
+          $numIdEstrutura,
+          true
+      );
+
+      $arrIdentificadores = [(string) $numIdEstrutura];
+    if (isset($objEstrutura->numeroDeIdentificacaoDaEstrutura)) {
+        $arrIdentificadores[] = (string) $objEstrutura->numeroDeIdentificacaoDaEstrutura;
+    }
+
+    if (isset($objEstrutura->hierarquia) && is_array($objEstrutura->hierarquia)) {
+      foreach ($objEstrutura->hierarquia as $objNivel) {
+          $numIdNivel = is_array($objNivel)
+              ? ($objNivel['numeroDeIdentificacaoDaEstrutura'] ?? null)
+              : ($objNivel->numeroDeIdentificacaoDaEstrutura ?? null);
+        if (!InfraString::isBolVazia($numIdNivel)) {
+            $arrIdentificadores[] = (string) $numIdNivel;
+        }
+      }
+    }
+
+      $this->arrCacheHierarquiaEstruturas[$strChaveCache] = array_values(array_unique($arrIdentificadores));
+      return $this->arrCacheHierarquiaEstruturas[$strChaveCache];
+  }
+
+  public function obterIdEstruturaUnidadeAtual()
+    {
+      $objUnidadeDTO = new PenUnidadeDTO();
+      $objUnidadeDTO->retNumIdUnidadeRH();
+      $objUnidadeDTO->setNumIdUnidade(SessaoSEI::getInstance()->getNumIdUnidadeAtual());
+
+      $objUnidadeDTO = $this->objUnidadeRN->consultarRN0125($objUnidadeDTO);
+      return isset($objUnidadeDTO) ? $objUnidadeDTO->getNumIdUnidadeRH() : null;
   }
 
   private function validarDocumentacaoExistende(InfraException $objInfraException, ProcedimentoDTO $objProcedimentoDTO, $strAtributoValidacao, $sinProcessoEmBloco = false)

--- a/src/rn/PenExpedirBlocoRN.php
+++ b/src/rn/PenExpedirBlocoRN.php
@@ -59,6 +59,14 @@ class PenExpedirBlocoRN extends InfraRN
         $objInfraException->adicionarValidacao('Unidade de destino não informado.');
     }
 
+      $this->objExpedirProcedimentoRN->validarDestinoOrgaoRemetente(
+          $objInfraException,
+          $objBlocoDTO->getNumIdRepositorioOrigem(),
+          $objBlocoDTO->getNumIdUnidadeOrigem(),
+          $objBlocoDTO->getNumIdRepositorioDestino(),
+          $objBlocoDTO->getNumIdUnidadeDestino()
+      );
+
       //TODO: Validar se usuário foi devidamente informada
     if (InfraString::isBolVazia($objBlocoDTO->getNumIdUsuario())) {
         $objInfraException->adicionarValidacao('Usuário não informado.');

--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -1480,8 +1480,6 @@ class ProcessoEletronicoRN extends InfraRN
       //Registra os dados do processo eletrônico
       $objProcessoEletronicoDTOFiltro = new ProcessoEletronicoDTO();
       $objProcessoEletronicoDTOFiltro->setStrNumeroRegistro($parObjProcessoEletronicoDTO->getStrNumeroRegistro());
-      $objProcessoEletronicoDTOFiltro->setDblIdProcedimento($parObjProcessoEletronicoDTO->getDblIdProcedimento());
-      $objProcessoEletronicoDTOFiltro->setStrStaTipoProtocolo($parObjProcessoEletronicoDTO->getStrStaTipoProtocolo());
       $objProcessoEletronicoDTOFiltro->retStrNumeroRegistro();
       $objProcessoEletronicoDTOFiltro->retDblIdProcedimento();
       $objProcessoEletronicoDTOFiltro->retStrStaTipoProtocolo();
@@ -1489,7 +1487,15 @@ class ProcessoEletronicoRN extends InfraRN
       $objProcessoEletronicoBD = new ProcessoEletronicoBD($this->getObjInfraIBanco());
       $objProcessoEletronicoDTO = $objProcessoEletronicoBD->consultar($objProcessoEletronicoDTOFiltro);
 
-    if(empty($objProcessoEletronicoDTO)) {
+    if (isset($objProcessoEletronicoDTO)) {
+        $this->validarAssociacaoNumeroRegistro(
+            $parObjProcessoEletronicoDTO->getStrNumeroRegistro(),
+            $objProcessoEletronicoDTO->getDblIdProcedimento(),
+            $parObjProcessoEletronicoDTO->getDblIdProcedimento()
+        );
+    } else {
+        $objProcessoEletronicoDTOFiltro->setDblIdProcedimento($parObjProcessoEletronicoDTO->getDblIdProcedimento());
+        $objProcessoEletronicoDTOFiltro->setStrStaTipoProtocolo($parObjProcessoEletronicoDTO->getStrStaTipoProtocolo());
         $objProcessoEletronicoDTO = $objProcessoEletronicoBD->cadastrar($objProcessoEletronicoDTOFiltro);
     }
 
@@ -1555,6 +1561,18 @@ class ProcessoEletronicoRN extends InfraRN
 
       $objTramiteDTO->setArrObjComponenteDigitalDTO($arrObjComponenteDigitalDTO);
       return $objProcessoEletronicoDTO;
+  }
+
+  public function validarAssociacaoNumeroRegistro($strNumeroRegistro, $dblIdProcedimentoExistente, $dblIdProcedimentoInformado)
+    {
+    if (!InfraString::isBolVazia($dblIdProcedimentoExistente) &&
+        !InfraString::isBolVazia($dblIdProcedimentoInformado) &&
+        (string) $dblIdProcedimentoExistente !== (string) $dblIdProcedimentoInformado) {
+        throw new InfraException(
+            "Módulo do Tramita: O NRE $strNumeroRegistro já está associado ao processo "
+            . "$dblIdProcedimentoExistente e não pode ser associado ao processo $dblIdProcedimentoInformado."
+        );
+    }
   }
 
     /**

--- a/src/rn/SincronizacaoExpedirProcedimentoRN.php
+++ b/src/rn/SincronizacaoExpedirProcedimentoRN.php
@@ -104,7 +104,7 @@ class SincronizacaoExpedirProcedimentoRN extends ExpedirProcedimentoRN
       $this->validarParametrosExpedicao($objInfraException, $objExpedirProcedimentoDTO);
 
       //Apresentao da mensagens de validao na janela da barra de progresso
-      if ($objInfraException->contemValidacoes() && $objExpedirProcedimentoDTO->getBolSinEnvioAutoMultiplosOrgaos() === false) {
+      if ($objInfraException->contemValidacoes()) {
         $objInfraException->lancarValidacoes();
       }
 

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoMesmoOrgaoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoExternoMesmoOrgaoTest.php
@@ -1,91 +1,38 @@
 <?php
 
-use PHPUnit\Framework\Attributes\{Group,Large,Depends};
-use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\{Group,Large};
 
 /**
- * Execution Groups
  * #[Group('execute_parallel_group1')]
  */
 class TramiteProcessoContendoDocumentoExternoMesmoOrgaoTest extends FixtureCenarioBaseTestCase
 {
-  public static $remetente;
-  public static $destinatario;
-  public static $processoTeste;
-  public static $documentoTeste;
-  public static $protocoloTeste;
-
-    /**
-     * Teste tramitar processo contendo documento gerado
-     * 
-     * @Depends CenarioBaseTestCase::setUpBeforeClass
-     * #[Large]
-     *
-     *
-     * @return void
-     */
-  public function test_tramitar_processo_contendo_documento_gerado()
+  /**
+   * #[Large]
+   */
+  public function test_bloquear_envio_externo_para_unidade_do_mesmo_orgao()
     {
-      // Configuração do dados para teste do cenário
-      self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
-      self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
-      self::$documentoTeste = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
+      $remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+      $processoTeste = $this->gerarDadosProcessoTeste($remetente);
+      $documentoTeste = $this->gerarDadosDocumentoExternoTeste($remetente);
 
-      //Configuração da unidade destinatário como outra unidade do mesmo órgão
-      self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
-      self::$destinatario['NOME_UNIDADE'] = self::$remetente['NOME_UNIDADE_SECUNDARIA'];
-      self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'] = self::$remetente['SIGLA_UNIDADE_SECUNDARIA_HIERARQUIA'];
+      $destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+      $destinatario['NOME_UNIDADE'] = $remetente['NOME_UNIDADE_SECUNDARIA'];
+      $destinatario['SIGLA_UNIDADE_HIERARQUIA'] = $remetente['SIGLA_UNIDADE_SECUNDARIA_HIERARQUIA'];
 
-      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
-      self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
-  }
+      $this->expectExceptionMessage(
+          mb_convert_encoding(
+              'Não é possível realizar o envio externo para o próprio órgão remetente.',
+              'UTF-8',
+              'ISO-8859-1'
+          )
+      );
 
-    /**
-     * #[Depends('test_tramitar_processo_contendo_documento_gerado')]
-     */
-  public function test_verificar_origem_processo_contendo_documento_gerado()
-    {
-      $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
-
-      $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
-
-      $this->abrirProcesso(self::$protocoloTeste);
-
-      // 6 - Verificar se situação atual do processo está como bloqueado
-      $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(2);
-          $this->paginaBase->refresh();
-        try { 
-            $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
-            $this->assertFalse($this->paginaProcesso->processoAberto());
-            $this->assertEquals($orgaosDiferentes, $this->paginaProcesso->processoBloqueado());
-            return true;
-        } catch (AssertionFailedError $e) {
-            return false;
-        }
-      }, PEN_WAIT_TIMEOUT);
-
-      // 7 - Validar se recibo de trâmite foi armazenado para o processo (envio e conclusão)
-      $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
-      $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
-      $this->validarRecibosTramite($mensagemRecibo, true, true);
-
-      // 8 - Validar histórico de trâmite do processo
-      $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
-
-      // 9 - Verificar se processo está na lista de Processos Tramitados Externamente
-      $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
-  }
-
-
-    /**
-     * #[Depends('test_verificar_origem_processo_contendo_documento_gerado')]
-     * #[Large]
-     */
-  public function test_verificar_destino_processo_contendo_documento_gerado()
-    {
-
-      self::$destinatario['SIGLA_UNIDADE'] = self::$remetente['SIGLA_UNIDADE_SECUNDARIA'];
-      $this->realizarValidacaoRecebimentoProcessoNoDestinatario(self::$processoTeste, self::$documentoTeste, self::$destinatario);
+      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(
+          $processoTeste,
+          $documentoTeste,
+          $remetente,
+          $destinatario
+      );
   }
 }

--- a/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoGeradoMesmoOrgaoTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoContendoDocumentoGeradoMesmoOrgaoTest.php
@@ -1,90 +1,39 @@
 <?php
 
-use PHPUnit\Framework\Attributes\{Group,Large,Depends};
-use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\{Group,Large};
 
 /**
- * Execution Groups
  * #[Group('execute_parallel_group1')]
  */
 class TramiteProcessoContendoDocumentoGeradoMesmoOrgaoTest extends FixtureCenarioBaseTestCase
 {
-  public static $remetente;
-  public static $destinatario;
-  public static $processoTeste;
-  public static $documentoTeste;
-  public static $protocoloTeste;
-
-    /**
-     * Test tramitar processo contendo documento gerado
-     * 
-     * @Depends CenarioBaseTestCase::setUpBeforeClass
-     * #[Large]
-     *
-     * @return void
-     */
-  public function test_tramitar_processo_contendo_documento_gerado()
+  /**
+   * #[Large]
+   */
+  public function test_bloquear_envio_externo_para_unidade_do_mesmo_orgao()
     {
-      // Configuração do dados para teste do cenário
-      self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
-      self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
-      self::$documentoTeste = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+      $remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+      $processoTeste = $this->gerarDadosProcessoTeste($remetente);
+      $documentoTeste = $this->gerarDadosDocumentoInternoTeste($remetente);
 
-      //Configuração da unidade destinatário como outra unidade do mesmo órgão
-      self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
-      self::$destinatario['SIGLA_UNIDADE'] = self::$remetente['SIGLA_UNIDADE_SECUNDARIA'];
-      self::$destinatario['NOME_UNIDADE'] = self::$remetente['NOME_UNIDADE_SECUNDARIA'];
-      self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'] = self::$remetente['SIGLA_UNIDADE_SECUNDARIA_HIERARQUIA'];
+      $destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+      $destinatario['SIGLA_UNIDADE'] = $remetente['SIGLA_UNIDADE_SECUNDARIA'];
+      $destinatario['NOME_UNIDADE'] = $remetente['NOME_UNIDADE_SECUNDARIA'];
+      $destinatario['SIGLA_UNIDADE_HIERARQUIA'] = $remetente['SIGLA_UNIDADE_SECUNDARIA_HIERARQUIA'];
 
-      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
-      self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
-  }
+      $this->expectExceptionMessage(
+          mb_convert_encoding(
+              'Não é possível realizar o envio externo para o próprio órgão remetente.',
+              'UTF-8',
+              'ISO-8859-1'
+          )
+      );
 
-    /**
-     * #[Depends('test_tramitar_processo_contendo_documento_gerado')]
-     * #[Large]
-     */
-  public function test_verificar_origem_processo_contendo_documento_gerado()
-    {
-      $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
-
-      $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
-
-      $this->abrirProcesso(self::$protocoloTeste);
-
-      // 6 - Verificar se situação atual do processo está como bloqueado
-      $this->waitUntil(function() use (&$orgaosDiferentes) {
-          sleep(2);
-          $this->paginaBase->refresh();
-        try { 
-            $this->assertStringNotContainsString(mb_convert_encoding("Processo em trâmite externo para ", 'UTF-8', 'ISO-8859-1'), $this->paginaProcesso->informacao());
-            $this->assertFalse($this->paginaProcesso->processoAberto());
-            $this->assertEquals($orgaosDiferentes, $this->paginaProcesso->processoBloqueado());
-            return true;
-        } catch (AssertionFailedError $e) {
-            return false;
-        }
-      }, PEN_WAIT_TIMEOUT);
-
-      // 7 - Validar se recibo de trâmite foi armazenado para o processo (envio e conclusão)
-      $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
-      $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
-      $this->validarRecibosTramite($mensagemRecibo, true, true);
-
-      // 8 - Validar histórico de trâmite do processo
-      $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
-
-      // 9 - Verificar se processo está na lista de Processos Tramitados Externamente
-      $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
-  }
-
-
-    /**
-     * #[Depends('test_verificar_origem_processo_contendo_documento_gerado')]
-     * #[Large]
-     */
-  public function test_verificar_destino_processo_contendo_documento_gerado()
-    {
-      $this->realizarValidacaoRecebimentoProcessoNoDestinatario(self::$processoTeste, self::$documentoTeste, self::$destinatario);
+      $this->realizarTramiteExternoSemValidacaoNoRemetenteFixture(
+          $processoTeste,
+          $documentoTeste,
+          $remetente,
+          $destinatario
+      );
   }
 }

--- a/tests_sei5/funcional/tests/TramiteProcessoOrgaosDiferentesMesmoRepositorioTest.php
+++ b/tests_sei5/funcional/tests/TramiteProcessoOrgaosDiferentesMesmoRepositorioTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use PHPUnit\Framework\Attributes\{Group,Large};
+
+/**
+ * #[Group('execute_parallel_group1')]
+ */
+class TramiteProcessoOrgaosDiferentesMesmoRepositorioTest extends FixtureCenarioBaseTestCase
+{
+  /**
+   * #[Large]
+   */
+  public function test_permitir_envio_entre_orgaos_diferentes_no_mesmo_repositorio()
+    {
+      $this->assertSame(
+          CONTEXTO_ORGAO_A_ID_REP_ESTRUTURAS,
+          CONTEXTO_ORGAO_B_ID_REP_ESTRUTURAS
+      );
+
+      $remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+      $destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+      $processoTeste = $this->gerarDadosProcessoTeste($remetente);
+      $documentoTeste = $this->gerarDadosDocumentoInternoTeste($remetente);
+
+      $this->realizarTramiteExternoComValidacaoNoRemetenteFixture(
+          $processoTeste,
+          $documentoTeste,
+          $remetente,
+          $destinatario
+      );
+  }
+}


### PR DESCRIPTION
  - valida a hierarquia da unidade destinatária para identificar o órgão;
  - impede tramitação individual, em lote, em bloco e automática;
  - adiciona pré-validação no envio pelo NRE;
  - mantém permitido o envio para órgão diferente no mesmo repositório;
  - adiciona testes unitários e funcionais para os cenários corrigidos.