### PR TITLE
feat: Corrigida a sincronização de metadados de processos e documentos entre órgãos durante o envio, reenvio e sincronização.

### DIFF
--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -636,6 +636,16 @@ class ExpedirProcedimentoRN extends InfraRN
         }
     }
 
+    if (!empty($dblIdProcedimento)) {
+        $objProcedimentoDTO = $this->consultarProcedimento($dblIdProcedimento);
+      if (!empty($objProcedimentoDTO->getStrNomeTipoPrioridade())) {
+          $cabecalho['propriedadesAdicionais'][] = [
+              'chave' => 'PEN_NOME_PRIORIDADE_PROCESSO',
+              'valor' => mb_convert_encoding($objProcedimentoDTO->getStrNomeTipoPrioridade(), 'UTF-8', 'ISO-8859-1')
+          ];
+      }
+    }
+
       return $cabecalho;
   }
 
@@ -1139,12 +1149,12 @@ class ExpedirProcedimentoRN extends InfraRN
         $this->atribuirDataHoraDeRegistroREST($documento, $documentoDTO->getDblIdProcedimento(), $documentoDTO->getDblIdDocumento());
         $documento = $this->atribuirEspecieDocumentalREST($documento, $documentoDTO, $parObjMetadadosTramiteAnterior);
         $documento = $this->atribuirNumeracaoDocumentoREST($documento, $documentoDTO);
-      if ($documentoDTO->getNumIdTipoConferencia() != null) {
-        $documento['identificacao']['complemento'] = json_encode([
-          'tipo_conferencia' => mb_convert_encoding($documentoDTO->getStrDescricaoTipoConferencia(), 'UTF-8', 'ISO-8859-1')
-        ]);
-      }
         
+        $identificacaoComplementar = json_decode($documento['identificacao']['complemento'] ?? '{}', true) ?: [];
+        $identificacaoComplementar['descricao'] = mb_convert_encoding($documentoDTO->getStrDescricaoProtocolo(), 'UTF-8', 'ISO-8859-1');
+        $identificacaoComplementar['nome_arvore'] = mb_convert_encoding($documentoDTO->getStrNomeArvore(), 'UTF-8', 'ISO-8859-1');
+        $documento['identificacao']['complemento'] = json_encode($identificacaoComplementar);
+
       if($documento['retirado'] === true) {
           $objComponenteDigitalDTO = new ComponenteDigitalDTO();
           $objComponenteDigitalDTO->retTodos();
@@ -2120,6 +2130,7 @@ class ExpedirProcedimentoRN extends InfraRN
       $objProcedimentoDTO->retDblIdProcedimento();
       $objProcedimentoDTO->retNumIdHipoteseLegalProtocolo();
       $objProcedimentoDTO->retStrProtocoloProcedimentoFormatadoPesquisa();
+      $objProcedimentoDTO->retStrNomeTipoPrioridade();
 
       return $this->objProcedimentoRN->consultarRN0201($objProcedimentoDTO);
   }
@@ -2227,6 +2238,7 @@ class ExpedirProcedimentoRN extends InfraRN
         $objDocumentoDTO->retStrNomeSerie();
         $objDocumentoDTO->retNumIdSerie();
         $objDocumentoDTO->retStrNumero();
+      $objDocumentoDTO->retStrNomeArvore();
         $objDocumentoDTO->retNumIdTipoConferencia();
         $objDocumentoDTO->retStrDescricaoTipoConferencia();
         $objDocumentoDTO->retStrStaDocumento();

--- a/src/rn/ReceberProcedimentoRN.php
+++ b/src/rn/ReceberProcedimentoRN.php
@@ -1058,7 +1058,8 @@ class ReceberProcedimentoRN extends InfraRN
       //TODO: Registrar que o processo foi recebido com outros apensados. Necessário para posterior reenvio
       $this->atribuirProcessosApensados($objProcedimentoDTO, $parObjProtocolo->processoApensado, $objMetadadosProcedimento);
 
-      //Realiza a alteração dos metadados do processo
+      // Sincroniza os metadados editaveis antes das restricoes de acesso.
+      $this->sincronizarMetadadosProcedimento($objProcedimentoDTO->getDblIdProcedimento(), $parObjProtocolo, $objMetadadosProcedimento->metadados);
       $this->alterarMetadadosProcedimento($objProcedimentoDTO->getDblIdProcedimento(), $parObjProtocolo, $objMetadadosProcedimento->metadados);
 
       $parObjProtocolo->idProcedimentoSEI = $objProcedimentoDTO->getDblIdProcedimento();
@@ -1286,6 +1287,42 @@ class ReceberProcedimentoRN extends InfraRN
       return $strNumeroProcesso;
   }
 
+  private function sincronizarMetadadosProcedimento($parNumIdProcedimento, $parObjProtocolo, $parObjMetadadosProcedimento)
+    {
+      $objProtocoloDTO = new ProtocoloDTO();
+      $objProtocoloDTO->setDblIdProtocolo($parNumIdProcedimento);
+      $objProtocoloDTO->setStrDescricao(mb_convert_encoding($this->objProcessoEletronicoRN->reduzirCampoTexto($parObjProtocolo->descricao, 100), 'ISO-8859-1', 'UTF-8'));
+      $objProtocoloDTO->setArrObjRelProtocoloAssuntoDTO([]);
+      $this->atribuirParticipantes($objProtocoloDTO, $parObjProtocolo->interessados ?? []);
+
+      $objProcedimentoDTO = new ProcedimentoDTO();
+      $objProcedimentoDTO->setDblIdProcedimento($parNumIdProcedimento);
+      $objProcedimentoDTO->setObjProtocoloDTO($objProtocoloDTO);
+
+      $objDestinatario = $this->destinatarioReal ?: $parObjMetadadosProcedimento->destinatario;
+      $this->atribuirTipoProcedimento(
+          $objProcedimentoDTO,
+          $parObjMetadadosProcedimento->remetente,
+          $objDestinatario,
+          $this->objPenParametroRN->getParametro('PEN_TIPO_PROCESSO_EXTERNO'),
+          mb_convert_encoding($parObjProtocolo->processoDeNegocio, 'ISO-8859-1', 'UTF-8')
+      );
+
+      $strNomeTipoPrioridade = $this->obterValorPropriedadeAdicional($parObjMetadadosProcedimento->propriedadesAdicionais ?? [], 'PEN_NOME_PRIORIDADE_PROCESSO');
+    if ($strNomeTipoPrioridade !== null) {
+        $objTipoPrioridadeDTO = new TipoPrioridadeDTO();
+        $objTipoPrioridadeDTO->retNumIdTipoPrioridade();
+        $objTipoPrioridadeDTO->setStrNome(mb_convert_encoding($strNomeTipoPrioridade, 'ISO-8859-1', 'UTF-8'));
+        $objTipoPrioridadeRN = new TipoPrioridadeRN();
+        $objTipoPrioridadeDTO = $objTipoPrioridadeRN->consultar($objTipoPrioridadeDTO);
+      if ($objTipoPrioridadeDTO != null) {
+          $objProcedimentoDTO->setNumIdTipoPrioridade($objTipoPrioridadeDTO->getNumIdTipoPrioridade());
+      }
+    }
+
+      $this->objProcedimentoRN->alterarRN0202($objProcedimentoDTO);
+  }
+
   private function alterarMetadadosProcedimento($parNumIdProcedimento, $parObjMetadadoProcedimento, $parObjMetadadosProcedimento = null)
     {
       $arrPropriedadesAdicionais = (isset($parObjMetadadosProcedimento->propriedadesAdicionais) && is_array($parObjMetadadosProcedimento->propriedadesAdicionais))
@@ -1375,6 +1412,40 @@ class ReceberProcedimentoRN extends InfraRN
 
   private function alterarMetadadosDocumento($parNumIdDocumento, $parObjMetadadoDocumento)
     {
+      $objDocumentoConsultaDTO = new DocumentoDTO();
+      $objDocumentoConsultaDTO->retStrStaDocumento();
+      $objDocumentoConsultaDTO->retDblIdProcedimento();
+      $objDocumentoConsultaDTO->setDblIdDocumento($parNumIdDocumento);
+      $objDocumentoRN = new DocumentoRN();
+      $objDocumentoConsultaDTO = $objDocumentoRN->consultarRN0005($objDocumentoConsultaDTO);
+
+      $objIdentificacao = $parObjMetadadoDocumento->identificacao ?? null;
+      $strComplemento = is_array($objIdentificacao) ? ($objIdentificacao['complemento'] ?? null) : ($objIdentificacao->complemento ?? null);
+      $arrMetadadosComplementares = json_decode($strComplemento, true) ?: [];
+
+      $objDocumentoDTO = new DocumentoDTO();
+      $objDocumentoDTO->setDblIdDocumento($parNumIdDocumento);
+      $objDocumentoDTO->setDblIdProcedimento($objDocumentoConsultaDTO->getDblIdProcedimento());
+      $objDocumentoDTO->setStrNomeArvore(mb_convert_encoding($arrMetadadosComplementares['nome_arvore'] ?? '', 'ISO-8859-1', 'UTF-8'));
+
+    if ($objDocumentoConsultaDTO->getStrStaDocumento() == DocumentoRN::$TD_EXTERNO) {
+        $objDocumentoDTO->setStrNumero(mb_convert_encoding($this->objProcessoEletronicoRN->reduzirCampoTexto($parObjMetadadoDocumento->descricao, 50), 'ISO-8859-1', 'UTF-8'));
+        $objSerieDTO = $this->obterSerieMapeada($parObjMetadadoDocumento);
+      if ($objSerieDTO != null) {
+          $objDocumentoDTO->setNumIdSerie($objSerieDTO->getNumIdSerie());
+      }
+    }
+
+      $objProtocoloMetadadosDTO = new ProtocoloDTO();
+      $objProtocoloMetadadosDTO->setDblIdProtocolo($parNumIdDocumento);
+      $objProtocoloMetadadosDTO->setStrDescricao(mb_convert_encoding($this->objProcessoEletronicoRN->reduzirCampoTexto($arrMetadadosComplementares['descricao'] ?? $parObjMetadadoDocumento->descricao, 100), 'ISO-8859-1', 'UTF-8'));
+    if ($objDocumentoConsultaDTO->getStrStaDocumento() == DocumentoRN::$TD_EXTERNO) {
+        $objProtocoloMetadadosDTO->setDtaGeracao($this->objProcessoEletronicoRN->converterDataSEI($parObjMetadadoDocumento->dataHoraDeProducao));
+    }
+      $objDocumentoDTO->setObjProtocoloDTO($objProtocoloMetadadosDTO);
+      $objDocumentoRN->alterarRN0004($objDocumentoDTO);
+
+      //
       //Realiza a alteração dos metadados do documento(Por hora, apenas do nível de sigilo e hipótese legal)
       $strNivelAcessoLocal = $this->obterNivelSigiloSEI($parObjMetadadoDocumento->nivelDeSigilo);
 
@@ -1872,12 +1943,7 @@ class ReceberProcedimentoRN extends InfraRN
           $objDocumentoDTO->setStrConteudo(null);
           $objDocumentoDTO->setStrStaDocumento(DocumentoRN::$TD_EXTERNO);
 
-          $identificacao = is_array($objDocumento->identificacao) ? json_decode($objDocumento->identificacao['complemento'], true) : json_decode($objDocumento->identificacao->complemento, true);
           $bolAutenticacao = false;
-        if (is_array($identificacao) && array_key_exists('tipo_conferencia', $identificacao)) {
-            $bolAutenticacao = true;
-            $objDocumentoDTO->setNumIdTipoConferencia(999);
-        }
 
           $objProtocoloDTO = new ProtocoloDTO();
           $objDocumentoDTO->setObjProtocoloDTO($objProtocoloDTO);


### PR DESCRIPTION
task #1225: Corrigida a sincronização de metadados de processos e documentos entre órgãos durante o envio, reenvio e sincronização.
Para processos, passaram a ser atualizados descrição, interessados, tipo de processo e prioridade, preservando as regras já existentes de nível de acesso e hipótese legal.
Para documentos, foram incluídas atualizações de descrição, nome na árvore, tipo documental, número e data de produção para documentos externos, além dos metadados aplicáveis aos documentos internos.
A alteração permite que modificações realizadas em um órgão sejam refletidas no processo ou documento correspondente no órgão destinatário.

task #1226: Corrigida a rejeição indevida de processos com documentos externos cujo Tipo de Conferência seja diferente de “Nato-digital”.
A causa era a atribuição de um identificador fixo de Tipo de Conferência (999) no recebimento do documento, que não correspondia necessariamente a um tipo válido no órgão destinatário e provocava a recusa do trâmite.
O recebimento agora não utiliza esse identificador fixo, eliminando a rejeição tanto no envio externo normal quanto no envio por sincronização.